### PR TITLE
Add noImplicitOverride rule

### DIFF
--- a/lib/error/error.ts
+++ b/lib/error/error.ts
@@ -24,7 +24,7 @@ export class JjError extends Error {
     Object.setPrototypeOf(this, Error.prototype);
   }
 
-  get message(): string {
+  override get message(): string {
     if (this.isInternalError) {
       return 'Internal Error - ' + this.prefixes.join(': ') + this.message;
     } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "pretty": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "noImplicitOverride": true
   },
   "include": ["src", "lib", "vitest.config.ts"]
 }


### PR DESCRIPTION
When I tried copybara-ing this back to Google, blaze complained that `override` must be added. This commit fixes that.

Unfortunately, the tsconfig in github.com/google/gts ([link](https://github.com/google/gts/blob/bd623c03dc9f319b64564cac7478162734739599/tsconfig-google.json#L4)) is a bit different from our internal version, so we need to manually add it here. We'll need to improve things here, either by making them the same, or disabling the warnings when compiling inside google, but that can be done later.