### PR TITLE
Refactor logging library to include global feedback and error callbacks

### DIFF
--- a/lib/error/error.ts
+++ b/lib/error/error.ts
@@ -36,20 +36,19 @@ export class JjError extends Error {
 
   constructor(message: string) {
     super(message);
-    Object.setPrototypeOf(this, Error.prototype);
+    Object.setPrototypeOf(this, JjError.prototype);
   }
 
-  override get message(): string {
+  getMessage(): string {
     if (this.isInternalError) {
-      return 'Internal Error - ' + this.prefixes.join(': ') + this.message;
-    } else {
-      return this.message;
+      return `Internal Error - ${this.message}`;
     }
+    return this.message;
   }
 
   addPrefix(prefix: string): JjError {
     if (prefix.length > 0) {
-      this.prefixes.unshift(prefix);
+      this.message = prefix + ': ' + this.message;
     }
     return this;
   }

--- a/lib/logging/error_callback.ts
+++ b/lib/logging/error_callback.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let errorCallback: (() => string) | undefined;
+
+/**
+ * Register a callback that will be called when an error is logged. The callback
+ * can return a string that will be appended to the error message.
+ * @param callback The callback to be registered.
+ */
+export function setGlobalErrorCallback(cb: () => string) {
+  errorCallback = cb;
+}
+
+/**
+ * Returns the global error callback.
+ */
+export function getGlobalErrorCallback() {
+  return errorCallback;
+}
+
+/**
+ * Clears the global error callback.
+ */
+export function removeGlobalErrorCallback() {
+  errorCallback = undefined;
+}

--- a/lib/logging/feedback.ts
+++ b/lib/logging/feedback.ts
@@ -1,10 +1,11 @@
 /**
  * Copyright 2026 Google LLC
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,19 +15,19 @@
  */
 
 /**
- * A generic logging interface.
+ * Invoked when an internal error is logged. The provider can decide whether
+ * to pop up a dialog to the user asking to file a bug.
  */
-export interface Logger {
-  /**
-   * Logs a provided message at the info level.
-   */
-  info(message: string): void;
+let feedbackProvider: ((error: Error) => void) | undefined;
 
-  /**
-   * Logs a provided message at the error level.
-   *
-   * @param message The message to log.
-   * @param args Additional arguments to log.
-   */
-  error(message: string | Error, ...args: unknown[]): void;
+export function setGlobalFeedbackProvider(input: (error: Error) => void) {
+  feedbackProvider = input;
+}
+
+export function removeGlobalFeedbackProvider() {
+  feedbackProvider = undefined;
+}
+
+export function fileFeedback(error: Error) {
+  feedbackProvider?.(error);
 }

--- a/lib/logging/logging.ts
+++ b/lib/logging/logging.ts
@@ -13,37 +13,60 @@
  * limitations under the License.
  */
 
-import {Logger} from './logger';
-import {JjError} from '../error/error';
 import * as vscode from 'vscode';
+
+import {JjError} from '../error/error';
+
+import {getGlobalErrorCallback} from './error_callback';
+import {fileFeedback} from './feedback';
+import {Logger} from './logger';
 
 let logger: Logger | undefined;
 
 /**
- * Add a logger that can be used globally.
+ * Sets the global logger.
  */
-export function setLogger(newLogger: Logger) {
+export function setGlobalLogger(newLogger: Logger) {
   logger = newLogger;
 }
 
-export function logInfo(message: string) {
-  if (!logger) {
-    throw new Error('logInfo failed: Logger has not been initialized yet');
-  }
-  logger.info(message);
+/**
+ * Removes the global logger.
+ */
+export function removeGlobalLogger() {
+  logger = undefined;
 }
 
+/**
+ * Logs an info message to the global logger.
+ */
+export function logInfo(message: string) {
+  logger?.info(message);
+}
+
+/**
+ * Logs an info message and shows it to the user.
+ */
 export function logAndShowInfo(message: string) {
   logInfo(message);
-  void vscode.window.showInformationMessage(message);
+  void vscode.window.showInformationMessage(
+    message,
+    // Pass an empty options object to bypass linting errors when using
+    // testing library
+    {},
+  );
 }
 
+/**
+ * Logs an error message to the global logger.
+ */
 export function logError(unknownError: unknown): JjError {
-  if (!logger) {
-    throw new Error('logError failed: Logger has not been initialized yet');
-  }
   const error = JjError.from(unknownError);
-  logger.error(error);
+  if (error.isLogged) {
+    return error;
+  }
+  error.isLogged = true;
+  logger?.error(error, getGlobalErrorCallback?.());
   return error;
 }
 
@@ -56,12 +79,23 @@ export function logAndShowUserError(unknownError: unknown): JjError {
     return error;
   }
   error.isShownToUser = true;
-  void vscode.window.showErrorMessage(error.message);
+  void vscode.window.showErrorMessage(
+    error.getMessage(),
+    // Pass an empty options object to bypass linting errors when using
+    // testing library.
+    {},
+  );
   return error;
 }
 
 export function logAndShowInternalError(unknownError: unknown): JjError {
   const error = JjError.from(unknownError);
   error.isInternalError = true;
-  return logAndShowUserError(error);
+  logError(error);
+  if (error.isShownToUser) {
+    return error;
+  }
+  error.isShownToUser = true;
+  fileFeedback(error);
+  return error;
 }

--- a/lib/logging/output_channel_logger.ts
+++ b/lib/logging/output_channel_logger.ts
@@ -13,20 +13,25 @@
  * limitations under the License.
  */
 
-import {Logger} from './logger';
 import * as vscode from 'vscode';
+
+import {Logger} from './logger';
 
 export class OutputChannelLogger implements Logger, vscode.Disposable {
   private readonly channel = vscode.window.createOutputChannel('JJ Extension', {
     log: true,
   });
 
+  get name(): string {
+    return this.channel.name;
+  }
+
   info(message: string) {
     this.channel.info(message);
   }
 
-  error(message: string | Error) {
-    this.channel.error(message);
+  error(message: string | Error, ...args: unknown[]) {
+    this.channel.error(message, ...args);
   }
 
   dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,12 +15,20 @@
 
 import * as vscode from 'vscode';
 import {OutputChannelLogger} from '../lib/logging/output_channel_logger';
-import {setLogger, logInfo} from '../lib/logging/logging';
+import {
+  setGlobalLogger,
+  logInfo,
+  removeGlobalLogger,
+} from '../lib/logging/logging';
 
 export async function activate(context: vscode.ExtensionContext) {
   const logger = new OutputChannelLogger();
   context.subscriptions.push(logger);
-  setLogger(logger);
+  setGlobalLogger(logger);
   logInfo(`Extension version: ${context.extension.packageJSON.build}`);
   logInfo('Extension activated successfully');
+}
+
+export async function deactivate() {
+  removeGlobalLogger();
 }


### PR DESCRIPTION
Aligns the public logging library with our internal implementation:

- error_callback.ts: Automatically dumps internal state (e.g., op head, internal VFS state) when an error is logged to simplify debugging.
- feedback.ts: Exposes a mechanism to prompt users to file a bug report when internal errors occur

Additionally, this commit:
- Fixes a few bugs in error.ts/logging.ts.
- Includes an automatic export from //third_party to jj-dojo.
