### PR TITLE
Introduce a rpc_protocol.ts for extension<->webview communication

### DIFF
--- a/.github/workflows/_test_run.yaml
+++ b/.github/workflows/_test_run.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: '_test_run'
 
 on:

--- a/.github/workflows/test-postsubmit.yaml
+++ b/.github/workflows/test-postsubmit.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'test-postsubmit'
 
 on:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: 'test'
 
 on:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 lockfileVersion: '9.0'
 
 settings:

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,10 +1,10 @@
 {
-  "spec_dir": "out/src",
+  "spec_dir": "out",
   "spec_files": [
     "**/*_test.js"
   ],
   "helpers": [
-    "testing/install_global_vscode.js"
+    "src/testing/install_global_vscode.js"
   ],
   "requires": []
 }

--- a/third_party/vscode/rpc_protocol/rpc_protocol.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol.ts
@@ -1,0 +1,244 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Copyright: This file was implemented independently without prior knowledge of its
+ * equivalent VS Code implementation (src/vs/workbench/services/extensions/common/rpcProtocol.ts).
+ * However, because it bears similarities, this work is attributed to and licensed under the
+ * VS Code license.
+ *
+ * In VS Code, the communication between an Extension and its webviews
+ * are done through one-way postMessage calls:
+ * - https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-an-extension-to-a-webview
+ * - https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-a-webview-to-an-extension
+ * This can be a bit inconvenient to use if either the extension or the webview expects
+ * a reply from the other side. This file exposes a `getExtensionApi` and `getWebviewApi`
+ * call that allows a two-way communication between an extension and its webviews.
+ *
+ * Another problem our `getExtensionApi` and `getWebviewApi` solves is avoiding lost messages.
+ * It can take webview time to start and load, and any messages passed before its ready may
+ * be lost. This is fixed by only exposing the rpc interface when both sides are ready.
+ */
+
+import {
+  createHandShakeMessage,
+  createRpcRequest,
+  createRpcResponse,
+  isHandShakeMessage,
+  isRpcRequest,
+  isRpcResponse,
+} from './rpc_protocol_utils';
+
+/**
+ * Retrieves the extension API. This function should only be used within a webview.
+ * It provides an interface to call functions exposed by the extension. It resolves
+ * only after both the extension and webview channels are initialized and ready for
+ * communication. Methods defined in the extension/webview apis that intends to be
+ * exposed to the other side must be prefixed with a dollar sign "$".
+ *
+ * @param channel The channel used to communicate with the extension.
+ * @param cb Given the api webview can use to call the extension, provide the
+ * implementation that should be invoked when the extension calls the webview.
+ * @param disposables The caller is responsible for disposing `disposables` once
+ * the communication channel is no longer needed.
+ */
+export async function getExtensionApi<E, W>(
+  channel: Channel,
+  cb: (extensionApi: E) => W,
+  disposables: Disposable[],
+): Promise<E> {
+  const extensionApi: E = createSender(channel, disposables);
+  createReceiver(channel, cb(extensionApi), disposables);
+  await shakeHands(channel);
+  return extensionApi;
+}
+
+/**
+ * Retrieves the webview API. This function should only be used within an extension.
+ * It provides an interface to call functions exposed by the webview. It resolves
+ * only after both the extension and webview channels are initialized and ready for
+ * communication. Methods defined in the extension/webview apis that intends to be
+ * exposed to the other side must be prefixed with a dollar sign "$".
+ *
+ * @param channel The channel used to communicate with the webview.
+ * @param cb Given the api extension can use to call the webview, provide the
+ * implementation that should be invoked when the webview calls the extension.
+ * @param disposables The caller is responsible for disposing `disposables` once
+ * the communication channel is no longer needed.
+ */
+export async function getWebviewApi<E, W>(
+  channel: Channel,
+  cb: (webviewApi: W) => E,
+  disposables: Disposable[],
+): Promise<W> {
+  const webviewApi: W = createSender(channel, disposables);
+  createReceiver(channel, cb(webviewApi), disposables);
+  await shakeHands(channel);
+  return webviewApi;
+}
+
+/**
+ * A disposable object, similar to vscode.Disposable.
+ * Declared separately to avoid a dependency on the vscode module.
+ */
+export interface Disposable {
+  // `dispose()` should be called when the object is no longer
+  // needed to clean up allocated resources.
+  dispose(): void;
+}
+
+/**
+ * A channel for sending and receiving messages.
+ */
+export interface Channel {
+  postMessage(message: unknown): void;
+  onMessage(callback: (event: unknown) => void): Disposable;
+}
+
+// If the rpc succeeded, `response` is set. Otherwise `err` is set.
+type Callback = (response: unknown, err: unknown) => void;
+
+function createSender(channel: Channel, disposables: Disposable[]) {
+  const pending = new Map<number, Callback>();
+  disposables.push(
+    channel.onMessage((event: unknown) => {
+      // We may not be the only one using this channel, ignore any
+      // messages not following our custom formats.
+      if (!isRpcResponse(event)) {
+        return;
+      }
+      const {response, id, err} = event.data;
+      // We got a response from the other side, invoke the stored
+      // callback.
+      pending.get(id)?.(response, err);
+      pending.delete(id);
+    }),
+  );
+  disposables.push({
+    dispose: () => {
+      for (const [, cb] of pending) {
+        cb(undefined, new Error('RPC channel disposed'));
+      }
+      pending.clear();
+    },
+  });
+  return createSenderProxy(channel, pending);
+}
+
+function createSenderProxy(channel: Channel, pending: Map<number, Callback>) {
+  let counter = 0;
+  const handler = {
+    get: (_target: unknown, name: string | symbol) => {
+      // Only hijack functions started with the '$' character.
+      if (typeof name !== 'string' || name.charAt(0) !== '$') {
+        return undefined;
+      }
+      return (...args: unknown[]) => {
+        // Create an identifier that is used to track the ID of a request.
+        // e.g. We send a request to the other side with a unique id, and the
+        // other side is expected to pass back a response with the same id.
+        const id = ++counter;
+        channel.postMessage(createRpcRequest({name, args, id}));
+        return new Promise((resolve, reject) => {
+          pending.set(id, (response: unknown, err: unknown) => {
+            if (err !== undefined) {
+              reject(err as Error);
+            } else {
+              resolve(response);
+            }
+          });
+        });
+      };
+    },
+  };
+  return new Proxy(Object.create(null), handler);
+}
+
+function createReceiver<T>(
+  channel: Channel,
+  impl: T,
+  disposables: Disposable[],
+) {
+  disposables.push(
+    channel.onMessage(async (event) => {
+      // We may not be the only one using this channel, ignore any
+      // messages not following our custom formats.
+      if (!isRpcRequest(event)) {
+        return;
+      }
+      const {name, args, id} = event.data;
+      let response;
+      let err;
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const fn = (impl as any)[name];
+        if (typeof fn !== 'function') {
+          throw new Error(`No such function: ${name}`);
+        }
+        response = await fn(...args);
+      } catch (e: unknown) {
+        err = e;
+      }
+      channel.postMessage(createRpcResponse({id, response, err}));
+    }),
+  );
+}
+
+// Returns once the other side has ACKed our message.
+//
+// Since webviews can take time to start, it is a good idea to call
+// this function to ensure it is fully up and ready before providing
+// the rpc interface to the user of our rpc protocol.
+async function shakeHands(channel: Channel) {
+  return new Promise<void>((resolve, reject) => {
+    const data = {
+      weHaveReceived: false,
+      theyHaveReceived: false,
+    };
+
+    const disposable = channel.onMessage((message: unknown) => {
+      if (!isHandShakeMessage(message)) {
+        return;
+      }
+      if (data.theyHaveReceived) {
+        return;
+      }
+      data.weHaveReceived = true;
+      data.theyHaveReceived = message.received;
+      if (data.theyHaveReceived) {
+        disposable.dispose();
+        resolve();
+      }
+    });
+
+    // Give a max of 10 seconds (0.1s * 100) for the webview to load.
+    const sleepSeconds = 0.1;
+    const repeat = 100;
+    void (async () => {
+      for (let i = 0; i < repeat; i++) {
+        channel.postMessage(
+          createHandShakeMessage({received: data.weHaveReceived}),
+        );
+        // Should still post a final message even if they have received.
+        if (data.theyHaveReceived) {
+          break;
+        }
+        await sleep(sleepSeconds * 1000);
+      }
+      if (!data.theyHaveReceived) {
+        disposable.dispose();
+        reject(
+          new Error(`Handshake timed out after ${sleepSeconds * repeat}s`),
+        );
+      }
+    })();
+  });
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
@@ -1,0 +1,213 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import {
+  Channel,
+  Disposable,
+  getExtensionApi,
+  getWebviewApi,
+} from './rpc_protocol';
+
+class MockChannel implements Channel {
+  readonly listeners = new Set<(event: unknown) => void>();
+  otherSide?: MockChannel;
+
+  postMessage(message: unknown): void {
+    setTimeout(() => {
+      if (this.otherSide) {
+        for (const listener of this.otherSide.listeners) {
+          try {
+            listener(message);
+          } catch (e) {
+            console.error('Error in message listener', e);
+          }
+        }
+      }
+    }, 0);
+  }
+
+  onMessage(callback: (event: unknown) => void): Disposable {
+    this.listeners.add(callback);
+    return {
+      dispose: () => {
+        this.listeners.delete(callback);
+      },
+    };
+  }
+}
+
+interface ExtensionApi {
+  $hello(name: string): Promise<string>;
+  $fail(): Promise<void>;
+  $add(a: number, b: number): Promise<number>;
+}
+
+interface WebviewApi {
+  $notify(message: string): Promise<void>;
+}
+
+describe('rpc_protocol', () => {
+  let webviewChannel: MockChannel;
+  let extensionChannel: MockChannel;
+
+  beforeEach(() => {
+    webviewChannel = new MockChannel();
+    extensionChannel = new MockChannel();
+    webviewChannel.otherSide = extensionChannel;
+    extensionChannel.otherSide = webviewChannel;
+  });
+
+  it('should complete handshake and allow bidirectional RPC calls', async () => {
+    const extensionImpl: ExtensionApi = {
+      $hello: async (name: string) => `Hello, ${name}`,
+      $fail: async () => {
+        throw new Error('Extension failed');
+      },
+      $add: async (a: number, b: number) => a + b,
+    };
+
+    let notifiedMessage: string | undefined;
+    const webviewImpl: WebviewApi = {
+      $notify: async (message: string) => {
+        notifiedMessage = message;
+      },
+    };
+
+    // Start both handshakes in parallel
+    const disposables: Disposable[] = [];
+    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+      webviewChannel,
+      (_extApi) => webviewImpl,
+      disposables,
+    );
+
+    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+      extensionChannel,
+      (_webApi) => extensionImpl,
+      disposables,
+    );
+
+    const [extApi, webApi] = await Promise.all([
+      getExtensionApiPromise,
+      getWebviewApiPromise,
+    ]);
+
+    expect(extApi).toBeDefined();
+    expect(webApi).toBeDefined();
+
+    // Test Webview calling Extension
+    const helloResponse = await extApi.$hello('World');
+    expect(helloResponse).toBe('Hello, World');
+
+    const addResponse = await extApi.$add(2, 3);
+    expect(addResponse).toBe(5);
+
+    // Test Extension calling Webview
+    await webApi.$notify('Test Message');
+    expect(notifiedMessage).toBe('Test Message');
+
+    dispose(disposables);
+  });
+
+  it('should propagate errors from implementation to caller', async () => {
+    const extensionImpl: ExtensionApi = {
+      $hello: async () => '',
+      $fail: async () => {
+        throw new Error('Intentional failure');
+      },
+      $add: async () => 0,
+    };
+
+    const webviewImpl: WebviewApi = {
+      $notify: async () => {},
+    };
+
+    const disposables: Disposable[] = [];
+    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+      webviewChannel,
+      (_extApi) => webviewImpl,
+      disposables,
+    );
+
+    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+      extensionChannel,
+      (_webApi) => extensionImpl,
+      disposables,
+    );
+
+    const [extApi] = await Promise.all([
+      getExtensionApiPromise,
+      getWebviewApiPromise,
+    ]);
+
+    try {
+      await extApi.$fail();
+      fail('Should have thrown');
+    } catch (e: unknown) {
+      // The error returned might be serialized, but in our mock it's passed directly.
+      // However, if it is serialized, it might just be an object with message, or it might be the Error object.
+      // Let's check if it is an Error or has the message.
+      expect(e).toBeDefined();
+      expect((e as Error).message || e).toContain('Intentional failure');
+    }
+  });
+
+  it('should handle concurrent RPC calls correctly', async () => {
+    const extensionImpl: ExtensionApi = {
+      $hello: async (name: string) => {
+        // Add some delay to ensure concurrency
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return `Hello, ${name}`;
+      },
+      $fail: async () => {},
+      $add: async (a: number, b: number) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return a + b;
+      },
+    };
+
+    const webviewImpl: WebviewApi = {
+      $notify: async () => {},
+    };
+
+    const disposables: Disposable[] = [];
+    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+      webviewChannel,
+      (_extApi) => webviewImpl,
+      disposables,
+    );
+
+    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+      extensionChannel,
+      (_webApi) => extensionImpl,
+      disposables,
+    );
+
+    const [extApi] = await Promise.all([
+      getExtensionApiPromise,
+      getWebviewApiPromise,
+    ]);
+
+    // Fire multiple requests concurrently
+    const results = await Promise.all([
+      extApi.$hello('Alice'),
+      extApi.$add(10, 20),
+      extApi.$hello('Bob'),
+      extApi.$add(1, 2),
+    ]);
+
+    expect(results[0]).toBe('Hello, Alice');
+    expect(results[1]).toBe(30);
+    expect(results[2]).toBe('Hello, Bob');
+    expect(results[3]).toBe(3);
+  });
+});
+
+function dispose(disposables: Disposable[]) {
+  for (const disposable of disposables) {
+    disposable.dispose();
+  }
+  disposables.length = 0;
+}

--- a/third_party/vscode/rpc_protocol/rpc_protocol_utils.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol_utils.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// We may not be the only ones using the channel. These are unique
+// ids to filter out noises.
+const REQUEST_PROTOCOL_ID = 'jj-dojo-rpc-protocol-request';
+const RESPONSE_PROTOCOL_ID = 'jj-dojo-rpc-protocol-response';
+const HANDSHAKE_PROTOCOL_ID = 'jj-dojo-rpc-protocol-handshake';
+
+interface RpcRequest {
+  rpcProtocolId: string;
+  data: {
+    name: string;
+    args: unknown[];
+    id: number;
+  };
+}
+
+/**
+ * Returns true if the provided event is a RPC request.
+ */
+export function isRpcRequest(event: unknown): event is RpcRequest {
+  return Boolean(
+    event &&
+    typeof event === 'object' &&
+    'rpcProtocolId' in event &&
+    event.rpcProtocolId === REQUEST_PROTOCOL_ID,
+  );
+}
+
+/**
+ * Creates a RPC request.
+ */
+export function createRpcRequest(data: RpcRequest['data']): RpcRequest {
+  return {
+    rpcProtocolId: REQUEST_PROTOCOL_ID,
+    data,
+  };
+}
+
+interface RpcResponse {
+  rpcProtocolId: string;
+  data: {
+    id: number;
+    response?: unknown;
+    err?: unknown;
+  };
+}
+
+/**
+ * Returns true if the provided event is a RPC response.
+ */
+export function isRpcResponse(event: unknown): event is RpcResponse {
+  return Boolean(
+    event &&
+    typeof event === 'object' &&
+    'rpcProtocolId' in event &&
+    event.rpcProtocolId === RESPONSE_PROTOCOL_ID,
+  );
+}
+
+/**
+ * Creates a RPC response.
+ */
+export function createRpcResponse(data: RpcResponse['data']): RpcResponse {
+  return {
+    rpcProtocolId: RESPONSE_PROTOCOL_ID,
+    data,
+  };
+}
+
+interface HandShakeMessage {
+  rpcProtocolId: string;
+  received: boolean;
+}
+
+/**
+ * Returns true if the provided event is a handshake message.
+ */
+export function isHandShakeMessage(event: unknown): event is HandShakeMessage {
+  return Boolean(
+    event &&
+    typeof event === 'object' &&
+    'rpcProtocolId' in event &&
+    event.rpcProtocolId === HANDSHAKE_PROTOCOL_ID,
+  );
+}
+
+/**
+ * Creates a handshake message.
+ */
+export function createHandShakeMessage(
+  data: Omit<HandShakeMessage, 'rpcProtocolId'>,
+): HandShakeMessage {
+  return {
+    rpcProtocolId: HANDSHAKE_PROTOCOL_ID,
+    ...data,
+  };
+}


### PR DESCRIPTION
In VS Code, the communication between an Extension and its webviews are done through one-way postMessage calls:
  - https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-an-extension-to-a-webview
  - https://code.visualstudio.com/api/extension-guides/webview#passing-messages-from-a-webview-to-an-extension This can be a bit inconvenient to use if either the extension or the webview expects a reply from the other side. This PR introduces a rpc_protocol.ts solution that fixes this.

