### PR TITLE
Turn prettier `arrowParens` on.

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -16,4 +16,5 @@
 
 module.exports = {
   ...require('gts/.prettierrc.json'),
+  arrowParens: 'always',
 };

--- a/src/testing/google_fakes/fake_text_document.ts
+++ b/src/testing/google_fakes/fake_text_document.ts
@@ -234,7 +234,7 @@ export class FakeTextEditor implements vscode.TextEditor {
       | readonly vscode.Range[],
     options?: {undoStopBefore: boolean; undoStopAfter: boolean},
   ): Promise<boolean> {
-    return this.edit(textEditBuilder => {
+    return this.edit((textEditBuilder) => {
       if (location instanceof vscode.Position) {
         textEditBuilder.insert(location, snippet.value);
       } else if (location instanceof vscode.Range) {

--- a/src/testing/install_vscode.ts
+++ b/src/testing/install_vscode.ts
@@ -54,7 +54,7 @@ export function installVscode() {
 
   // Assign the enums first, so subsequent code can reference them using
   // vscode.EnumName.
-  Object.keys(vscodeEnums).forEach(key => {
+  Object.keys(vscodeEnums).forEach((key) => {
     vscodeAsRecord[key] = (vscodeEnums as Record<string, unknown>)[key];
   });
 
@@ -72,7 +72,7 @@ export function installVscode() {
     EventEmitter: FakeEventEmitter,
     LogOutputChannel: FakeLogOutputChannel,
   };
-  Object.keys(basicClasses).forEach(key => {
+  Object.keys(basicClasses).forEach((key) => {
     vscodeAsRecord[key] = (basicClasses as Record<string, unknown>)[key];
   });
 
@@ -83,7 +83,7 @@ export function installVscode() {
     commands: new FakeCommands(),
     window: new FakeWindow(),
   };
-  Object.keys(restOfClasses).forEach(key => {
+  Object.keys(restOfClasses).forEach((key) => {
     vscodeAsRecord[key] = (restOfClasses as Record<string, unknown>)[key];
   });
 

--- a/src/ui/merge_conflict/commands.ts
+++ b/src/ui/merge_conflict/commands.ts
@@ -30,7 +30,7 @@ export function acceptAllSides(args: unknown[]) {
   const conflict = args[0] as Conflict;
   const editor = getActiveTextEditor();
   const resolvedText = getResolvedTextForAllSides(
-    conflict.sides.map(side => editor.document.getText(side.range)),
+    conflict.sides.map((side) => editor.document.getText(side.range)),
   );
   editor.edit((edit: vscode.TextEditorEdit) => {
     edit.replace(getRangeToReplace(conflict, resolvedText), resolvedText);

--- a/src/ui/merge_conflict/decorator.ts
+++ b/src/ui/merge_conflict/decorator.ts
@@ -61,7 +61,7 @@ export class ConflictDecorator implements vscode.Disposable {
       this.applyDecorations(event);
     }
     this.disposables.push(
-      tracker.onDidChange(event => {
+      tracker.onDidChange((event) => {
         this.applyDecorations(event);
       }),
     );

--- a/src/ui/merge_conflict/decorator_test.ts
+++ b/src/ui/merge_conflict/decorator_test.ts
@@ -75,7 +75,7 @@ describe('Decorator', () => {
       fakeTextDocumentChangeEvent(document),
     );
 
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     expect(editor.setDecorations).toHaveBeenCalledTimes(5);
     decorator.dispose();
   });

--- a/src/ui/merge_conflict/resolver_test.ts
+++ b/src/ui/merge_conflict/resolver_test.ts
@@ -73,7 +73,7 @@ describe('getResolvedTextForAllSides', () => {
     expect(conflicts.length).toEqual(1);
     const conflict = conflicts[0];
     return getResolvedTextForAllSides(
-      conflict.sides.map(side => document.getText(side.range)),
+      conflict.sides.map((side) => document.getText(side.range)),
     );
   }
 

--- a/src/ui/merge_conflict/tracker.ts
+++ b/src/ui/merge_conflict/tracker.ts
@@ -47,14 +47,14 @@ export class ConflictTracker implements vscode.Disposable {
     }
     this.disposables.push(
       this.onDidChangeEmitter,
-      vscode.workspace.onDidChangeTextDocument(event => {
+      vscode.workspace.onDidChangeTextDocument((event) => {
         for (const editor of vscode.window.visibleTextEditors) {
           if (editor.document === event.document) {
             this.processEditor(editor);
           }
         }
       }),
-      vscode.window.onDidChangeVisibleTextEditors(editors => {
+      vscode.window.onDidChangeVisibleTextEditors((editors) => {
         for (const editor of editors) {
           this.processEditor(editor);
         }


### PR DESCRIPTION
We have this on internally. Since most of the code is copied from internal, let's use the same settings. I also ran `npm run fix` which automatically reformats all existing code

