### PR TITLE
Fix rpc_protocol providing senders too early

### DIFF
--- a/third_party/vscode/rpc_protocol/rpc_protocol.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol.ts
@@ -44,14 +44,19 @@ import {
  * @param disposables The caller is responsible for disposing `disposables` once
  * the communication channel is no longer needed.
  */
-export async function getExtensionApi<E, W>(
+export function getExtensionApi<E, W>(
   channel: Channel,
   cb: (extensionApi: E) => W,
   disposables: Disposable[],
-): Promise<E> {
-  const extensionApi: E = createSender(channel, disposables);
+): E {
+  const {blocker, unblock} = getBlocker();
+  const extensionApi: E = createSender(channel, disposables, blocker);
   createReceiver(channel, cb(extensionApi), disposables);
-  await shakeHands(channel);
+  void shakeHands(channel).then(() => {
+    unblock();
+  });
+  // Return the sender immediately. sender is programmed to only send
+  // requests after `unblock` is called.
   return extensionApi;
 }
 
@@ -68,14 +73,19 @@ export async function getExtensionApi<E, W>(
  * @param disposables The caller is responsible for disposing `disposables` once
  * the communication channel is no longer needed.
  */
-export async function getWebviewApi<E, W>(
+export function getWebviewApi<E, W>(
   channel: Channel,
   cb: (webviewApi: W) => E,
   disposables: Disposable[],
-): Promise<W> {
-  const webviewApi: W = createSender(channel, disposables);
+): W {
+  const {blocker, unblock} = getBlocker();
+  const webviewApi: W = createSender(channel, disposables, blocker);
   createReceiver(channel, cb(webviewApi), disposables);
-  await shakeHands(channel);
+  void shakeHands(channel).then(() => {
+    unblock();
+  });
+  // Return the sender immediately. sender is programmed to only send
+  // requests after `unblock` is called.
   return webviewApi;
 }
 
@@ -100,7 +110,11 @@ export interface Channel {
 // If the rpc succeeded, `response` is set. Otherwise `err` is set.
 type Callback = (response: unknown, err: Error | undefined) => void;
 
-function createSender(channel: Channel, disposables: Disposable[]) {
+function createSender(
+  channel: Channel,
+  disposables: Disposable[],
+  receiverReady: Promise<void>,
+) {
   const pending = new Map<number, Callback>();
   disposables.push(
     channel.onMessage((event: unknown) => {
@@ -124,10 +138,14 @@ function createSender(channel: Channel, disposables: Disposable[]) {
       pending.clear();
     },
   });
-  return createSenderProxy(channel, pending);
+  return createSenderProxy(channel, pending, receiverReady);
 }
 
-function createSenderProxy(channel: Channel, pending: Map<number, Callback>) {
+function createSenderProxy(
+  channel: Channel,
+  pending: Map<number, Callback>,
+  receiverReady: Promise<void>,
+) {
   let counter = 0;
   const handler = {
     get: (_target: unknown, name: string | symbol) => {
@@ -135,11 +153,12 @@ function createSenderProxy(channel: Channel, pending: Map<number, Callback>) {
       if (typeof name !== 'string' || name.charAt(0) !== '$') {
         return undefined;
       }
-      return (...args: unknown[]) => {
+      return async (...args: unknown[]) => {
         // Create an identifier that is used to track the ID of a request.
         // e.g. We send a request to the other side with a unique id, and the
         // other side is expected to pass back a response with the same id.
         const id = ++counter;
+        await receiverReady;
         channel.postMessage(createRpcRequest({name, args, id}));
         return new Promise((resolve, reject) => {
           pending.set(id, (response: unknown, err: Error | undefined) => {
@@ -283,4 +302,27 @@ function sleep(ms: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
+}
+
+/**
+ * @returns a pair of objects. `blocker` is a promise that will remain unresolved
+ * until `unblock` is called.
+ */
+function getBlocker(): {
+  blocker: Promise<void>;
+  unblock: () => {};
+} {
+  let unblock;
+  const blocker = new Promise<void>((resolve) => {
+    // JavaScript guarantees that this line is called immediately,
+    // so `unblock` should always be assigned.
+    unblock = resolve;
+  });
+  if (!unblock) {
+    throw new Error('Programming error: unblock is not assigned in promise');
+  }
+  return {
+    blocker,
+    unblock,
+  };
 }

--- a/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
@@ -75,24 +75,19 @@ describe('rpc_protocol', () => {
       },
     };
 
-    // Start both handshakes in parallel
+    // Initialize both APIs synchronously
     const disposables: Disposable[] = [];
-    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+    const extApi = getExtensionApi<ExtensionApi, WebviewApi>(
       webviewChannel,
       (_extApi) => webviewImpl,
       disposables,
     );
 
-    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+    const webApi = getWebviewApi<ExtensionApi, WebviewApi>(
       extensionChannel,
       (_webApi) => extensionImpl,
       disposables,
     );
-
-    const [extApi, webApi] = await Promise.all([
-      getExtensionApiPromise,
-      getWebviewApiPromise,
-    ]);
 
     expect(extApi).toBeDefined();
     expect(webApi).toBeDefined();
@@ -111,6 +106,53 @@ describe('rpc_protocol', () => {
     dispose(disposables);
   });
 
+  it('should return API objects synchronously and block calls until handshake completes', async () => {
+    let handshakeCompleted = false;
+
+    const extensionImpl: ExtensionApi = {
+      $hello: async (name: string) => {
+        expect(handshakeCompleted).toBeTrue();
+        return `Hello, ${name}`;
+      },
+      $fail: async () => {},
+      $add: async (a: number, b: number) => a + b,
+    };
+
+    const webviewImpl: WebviewApi = {
+      $notify: async () => {},
+    };
+
+    const disposables: Disposable[] = [];
+
+    // Call getExtensionApi and getWebviewApi synchronously
+    const extApi = getExtensionApi<ExtensionApi, WebviewApi>(
+      webviewChannel,
+      (_extApi) => webviewImpl,
+      disposables,
+    );
+
+    const webApi = getWebviewApi<ExtensionApi, WebviewApi>(
+      extensionChannel,
+      (_webApi) => extensionImpl,
+      disposables,
+    );
+
+    expect(extApi).toBeDefined();
+    expect(webApi).toBeDefined();
+
+    // Call $hello immediately before handshake has completed
+    const helloPromise = extApi.$hello('World');
+
+    // Give handshake a tick to complete (MockChannel uses setTimeout 0)
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    handshakeCompleted = true;
+
+    const response = await helloPromise;
+    expect(response).toBe('Hello, World');
+
+    dispose(disposables);
+  });
+
   it('should propagate errors from implementation to caller', async () => {
     const extensionImpl: ExtensionApi = {
       $hello: async () => '',
@@ -125,33 +167,27 @@ describe('rpc_protocol', () => {
     };
 
     const disposables: Disposable[] = [];
-    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+    const extApi = getExtensionApi<ExtensionApi, WebviewApi>(
       webviewChannel,
       (_extApi) => webviewImpl,
       disposables,
     );
 
-    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+    getWebviewApi<ExtensionApi, WebviewApi>(
       extensionChannel,
       (_webApi) => extensionImpl,
       disposables,
     );
 
-    const [extApi] = await Promise.all([
-      getExtensionApiPromise,
-      getWebviewApiPromise,
-    ]);
-
     try {
       await extApi.$fail();
       fail('Should have thrown');
     } catch (e: unknown) {
-      // The error returned might be serialized, but in our mock it's passed directly.
-      // However, if it is serialized, it might just be an object with message, or it might be the Error object.
-      // Let's check if it is an Error or has the message.
       expect(e).toBeDefined();
       expect((e as Error).message || e).toContain('Intentional failure');
     }
+
+    dispose(disposables);
   });
 
   it('should handle concurrent RPC calls correctly', async () => {
@@ -173,22 +209,17 @@ describe('rpc_protocol', () => {
     };
 
     const disposables: Disposable[] = [];
-    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+    const extApi = getExtensionApi<ExtensionApi, WebviewApi>(
       webviewChannel,
       (_extApi) => webviewImpl,
       disposables,
     );
 
-    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+    getWebviewApi<ExtensionApi, WebviewApi>(
       extensionChannel,
       (_webApi) => extensionImpl,
       disposables,
     );
-
-    const [extApi] = await Promise.all([
-      getExtensionApiPromise,
-      getWebviewApiPromise,
-    ]);
 
     // Fire multiple requests concurrently
     const results = await Promise.all([
@@ -227,22 +258,17 @@ describe('rpc_protocol', () => {
     };
 
     const disposables: Disposable[] = [];
-    const getExtensionApiPromise = getExtensionApi<ExtensionApi, WebviewApi>(
+    const extApi = getExtensionApi<ExtensionApi, WebviewApi>(
       webviewChannel,
       (_extApi) => webviewImpl,
       disposables,
     );
 
-    const getWebviewApiPromise = getWebviewApi<ExtensionApi, WebviewApi>(
+    getWebviewApi<ExtensionApi, WebviewApi>(
       extensionChannel,
       (_webApi) => extensionImpl,
       disposables,
     );
-
-    const [extApi] = await Promise.all([
-      getExtensionApiPromise,
-      getWebviewApiPromise,
-    ]);
 
     const helloResponse = await extApi.$hello('World');
     expect(helloResponse).toBe('Hello from class, World');


### PR DESCRIPTION
This didn't trigger any issues, but it's still nice to fix. In createReceiver, we invoke the callback with the sender. This is done before `shakeHands`, which means the caller obtained the sender api before the channel is fully initialized. This PR fixes that. It also changed the return type from `Promise<E>` to E to match the internal rpc protocol we have inside Google.
