### PR TITLE
Use `npm run compile` for tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,7 +4,7 @@
     {
       "label": "Compile extension",
       "type": "shell",
-      "command": "bazel build //:compile",
+      "command": "npm run compile",
       "problemMatcher": [],
       "isBackground": false,
       "presentation": {


### PR DESCRIPTION
Let's just do `npm run compile`, so we don't risk `bazel run <target>` going out of sync between package.json and .vscode/tasks.json. 
