### PR TITLE
Move commit_graph/components to upstream

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
 load("@npm//:@vscode/vsce/package_json.bzl", vsce_bin = "bin")
@@ -30,10 +31,12 @@ ts_project(
     srcs = glob(
         [
             "src/**/*.ts",
+            "third_party/**/*.ts",
         ],
         exclude = [
             "src/testing/**",
             "src/**/*_test.ts",
+            "third_party/**/*_test.ts",
         ],
     ),
     composite = True,
@@ -50,6 +53,9 @@ ts_project(
         # like node. 
         "//:node_modules/@types/node",
         "//:node_modules/@types/vscode",
+        "//:node_modules/lit",
+        "//:node_modules/safevalues",
+        "//:node_modules/@vscode-elements/elements",
     ],
 )
 
@@ -59,7 +65,7 @@ ts_project(
         [
             "src/testing/**/*.ts",
             "src/**/*_test.ts",
-            "third_party/**/*.ts",
+            "third_party/**/*_test.ts",
         ],
     ),
     composite = True,
@@ -74,12 +80,28 @@ ts_project(
     ],
 )
 
+esbuild(
+    name = "webview_bundle",
+    entry_point = "out/src/ui/commit_graph/webview_module.js",
+    output = "out/src/ui/commit_graph/webview_module.bundle.js",
+    format = "esm",
+    target = "es2020",
+    tsconfig = "tsconfig.json",
+    deps = [
+        ":compile",
+        "//:node_modules/lit",
+        "//:node_modules/safevalues",
+        "//:node_modules/@vscode-elements/elements",
+    ],
+)
 
 js_library(
     name = "extension",
     srcs = [
         "package.json",
+        "src/ui/commit_graph/components/_jj_graph_base_styles.css",
         ":compile",
+        ":webview_bundle",
     ],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,7 @@ module(
 
 bazel_dep(name = "aspect_rules_js", version = "3.1.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.9")
+bazel_dep(name = "aspect_rules_esbuild", version = "0.26.0")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -27,7 +27,10 @@
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.22.5/source.json": "ac2c3213df8f985785f1d0aeb7f0f73d5324e6e67d593d9b9470fb74a25d4a9b",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.7.7/MODULE.bazel": "491f8681205e31bb57892d67442ce448cda4f472a8e6b3dc062865e29a64f89c",
     "https://bcr.bazel.build/modules/aspect_bazel_lib/2.8.1/MODULE.bazel": "812d2dd42f65dca362152101fbec418029cc8fd34cbad1a2fde905383d705838",
+    "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.26.0/MODULE.bazel": "6c902d97038c3ab07b6c4e67c97abc61b20182fcfa84fa7dee82fc724f12e455",
+    "https://bcr.bazel.build/modules/aspect_rules_esbuild/0.26.0/source.json": "4cc3ece7ab661bb391a9e24fe55c4b567d60a9ea9d9e91d772dad373cbcb6217",
     "https://bcr.bazel.build/modules/aspect_rules_js/2.0.0/MODULE.bazel": "b45b507574aa60a92796e3e13c195cd5744b3b8aff516a9c0cb5ae6a048161c5",
+    "https://bcr.bazel.build/modules/aspect_rules_js/3.0.3/MODULE.bazel": "28a30e8fc33bf64a67835d64d124f6e05a7d59648dcb27b110fb3502f761e503",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.1.1/MODULE.bazel": "b83cf3ee44837345f1c926d70b96453deb5e244de43d08dcd7acad8d381c275a",
     "https://bcr.bazel.build/modules/aspect_rules_js/3.1.1/source.json": "2806c2d7ce5993f68b74df5f3e2de45d4b2a5798afedd459d88e37c75562da97",
     "https://bcr.bazel.build/modules/aspect_rules_ts/3.8.9/MODULE.bazel": "bd5f9ebf517cfcd377eaa7ce1cb16035d167f00774b77789909590c53bc6f20c",
@@ -181,6 +184,7 @@
     "https://bcr.bazel.build/modules/rules_license/1.0.0/MODULE.bazel": "a7fda60eefdf3d8c827262ba499957e4df06f659330bbe6cdbdb975b768bb65c",
     "https://bcr.bazel.build/modules/rules_license/1.0.0/source.json": "a52c89e54cc311196e478f8382df91c15f7a2bfdf4c6cd0e2675cc2ff0b56efb",
     "https://bcr.bazel.build/modules/rules_nodejs/6.2.0/MODULE.bazel": "ec27907f55eb34705adb4e8257952162a2d4c3ed0f0b3b4c3c1aad1fac7be35e",
+    "https://bcr.bazel.build/modules/rules_nodejs/6.5.0/MODULE.bazel": "546d0cf79f36f9f6e080816045f97234b071c205f4542e3351bd4424282a8810",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.3/MODULE.bazel": "c22a48b2a0dbf05a9dc5f83837bbc24c226c1f6e618de3c3a610044c9f336056",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.4/MODULE.bazel": "e6a241a55c82e999145553d2e00a08fc6ebadf62b63d108fb5e984696ffd0bd2",
     "https://bcr.bazel.build/modules/rules_nodejs/6.7.4/source.json": "34e7a8a3b4c8d630ac0e0492b3fed9dba41fe008a0edf220b7d88fa38ac53698",
@@ -244,6 +248,106 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@aspect_rules_esbuild+//esbuild:extensions.bzl%esbuild": {
+      "general": {
+        "bzlTransitiveDigest": "ilJsM+WEt9IPvMW7AewM1yf264AqfqVBfP50m5o4Ruc=",
+        "usagesDigest": "LSQ+zZp7JNgnBONTxxXnwGr4NTh2qtQYk7qwXXz5qWo=",
+        "recordedInputs": [
+          "REPO_MAPPING:aspect_bazel_lib+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:aspect_bazel_lib+,bazel_tools bazel_tools",
+          "REPO_MAPPING:aspect_rules_esbuild+,aspect_rules_js aspect_rules_js+",
+          "REPO_MAPPING:aspect_rules_esbuild+,aspect_tools_telemetry_report aspect_tools_telemetry++telemetry+aspect_tools_telemetry_report",
+          "REPO_MAPPING:aspect_rules_esbuild+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:aspect_rules_js+,aspect_rules_js aspect_rules_js+",
+          "REPO_MAPPING:aspect_rules_js+,aspect_tools_telemetry_report aspect_tools_telemetry++telemetry+aspect_tools_telemetry_report",
+          "REPO_MAPPING:aspect_rules_js+,bazel_features bazel_features+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_lib bazel_lib+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:aspect_rules_js+,bazel_tools bazel_tools",
+          "REPO_MAPPING:aspect_rules_js+,protobuf protobuf+",
+          "REPO_MAPPING:aspect_rules_js+,tar.bzl tar.bzl+",
+          "REPO_MAPPING:bazel_features+,bazel_features_globals bazel_features++version_extension+bazel_features_globals",
+          "REPO_MAPPING:bazel_features+,bazel_features_version bazel_features++version_extension+bazel_features_version",
+          "REPO_MAPPING:bazel_lib+,bazel_lib bazel_lib+",
+          "REPO_MAPPING:bazel_lib+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:bazel_lib+,bazel_tools bazel_tools",
+          "REPO_MAPPING:protobuf+,proto_bazel_features bazel_features+",
+          "REPO_MAPPING:tar.bzl+,aspect_bazel_lib aspect_bazel_lib+",
+          "REPO_MAPPING:tar.bzl+,bazel_skylib bazel_skylib+",
+          "REPO_MAPPING:tar.bzl+,tar.bzl tar.bzl+"
+        ],
+        "generatedRepoSpecs": {
+          "esbuild_darwin-x64": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild:repositories.bzl%esbuild_repositories",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "platform": "darwin-x64"
+            }
+          },
+          "esbuild_darwin-arm64": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild:repositories.bzl%esbuild_repositories",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "platform": "darwin-arm64"
+            }
+          },
+          "esbuild_linux-x64": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild:repositories.bzl%esbuild_repositories",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "platform": "linux-x64"
+            }
+          },
+          "esbuild_linux-arm64": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild:repositories.bzl%esbuild_repositories",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "platform": "linux-arm64"
+            }
+          },
+          "esbuild_win32-x64": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild:repositories.bzl%esbuild_repositories",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "platform": "win32-x64"
+            }
+          },
+          "esbuild_toolchains": {
+            "repoRuleId": "@@aspect_rules_esbuild+//esbuild/private:toolchains_repo.bzl%toolchains_repo",
+            "attributes": {
+              "esbuild_version": "0.19.9",
+              "user_repository_name": "esbuild"
+            }
+          },
+          "npm__esbuild_0.19.9": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_rule",
+            "attributes": {
+              "key": "npm__esbuild_0.19.9",
+              "package": "esbuild",
+              "version": "0.19.9",
+              "root_package": "",
+              "integrity": "sha512-U9CHtKSy+EpPsEBa+/A2gMs/h3ylBC0H0KSqIg7tpztHerLi6nrrcoUJAkNCEPumx8yJ+Byic4BVwHgRbN0TBg==",
+              "lifecycle_hooks": [],
+              "exclude_package_contents_presets": []
+            }
+          },
+          "npm__esbuild_0.19.9__links": {
+            "repoRuleId": "@@aspect_rules_js+//npm/private:npm_import.bzl%npm_import_links_rule",
+            "attributes": {
+              "key": "npm__esbuild_0.19.9",
+              "package": "esbuild",
+              "version": "0.19.9",
+              "root_package": "",
+              "deps": {},
+              "deps_oss": {},
+              "deps_cpus": {},
+              "lifecycle_build_target": false,
+              "exclude_package_contents_presets": []
+            }
+          }
+        }
+      }
+    },
     "@@aspect_rules_ts+//ts:extensions.bzl%ext": {
       "general": {
         "bzlTransitiveDigest": "axls+7DzE6tzeppZH+xWR9lJ/k6OusXMYmf7L7yH0eU=",
@@ -269,7 +373,7 @@
     "@@aspect_tools_telemetry+//:extension.bzl%telemetry": {
       "general": {
         "bzlTransitiveDigest": "cl5A2O84vDL6Tt+Qga8FCj1DUDGqn+e7ly5rZ+4xvcc=",
-        "usagesDigest": "yiolNEEhiLsCU/w74vPG0thZ+0sLEuvsti2ErQf66NU=",
+        "usagesDigest": "x8132iIds9gXqzzxE0SAZ3Hjxhjmzkbtg76ONdIXC1c=",
         "recordedInputs": [
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_lib bazel_lib+",
           "REPO_MAPPING:aspect_tools_telemetry+,bazel_skylib bazel_skylib+"
@@ -281,6 +385,7 @@
               "deps": {
                 "aspect_rules_js": "3.1.1",
                 "aspect_rules_ts": "3.8.9",
+                "aspect_rules_esbuild": "0.26.0",
                 "aspect_tools_telemetry": "0.3.3"
               }
             }

--- a/src/ui/commit_graph/components/_jj_graph_base_styles.css
+++ b/src/ui/commit_graph/components/_jj_graph_base_styles.css
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+body {
+  padding: 0;
+}
+
+body.vscode-light {
+  --commit-row-highlighted-text: #994f00;
+}
+
+body.vscode-dark {
+  --commit-row-highlighted-text: #fcad70;
+}
+
+/* The colors for inactive glyphs and lines. */
+body {
+  --inactiveLineColor: var(--vscode-foreground);
+}
+
+body.vscode-light {
+  --inactiveLineColor: lightgray;
+}
+
+body.vscode-dark {
+  --inactiveLineColor: #616161;
+}
+
+/* The colors for drag-and-drop abandon section. */
+body {
+  --jj-garbageSection-color: #939393;
+  --jj-garbageSection-backgroundColor: transparent;
+  --jj-garbageSection-borderColor: #939393;
+
+  --jj-garbageSection-hoverColor: inherit;
+  --jj-garbageSection-hoverBackgroundColor: var(
+    --vscode-diffEditor-removedLineBackground
+  );
+  --jj-garbageSection-hoverBorderColor: #f59c8d;
+}
+
+/* The colors for actively selected commit rows. */
+body {
+  --jj-activeCommitRow-background: var(--vscode-list-activeSelectionBackground);
+  --jj-activeCommitRow-foreground: var(--vscode-list-activeSelectionForeground);
+}

--- a/src/ui/commit_graph/components/app.ts
+++ b/src/ui/commit_graph/components/app.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {getFocusedCommits} from '../algorithms/focus_mode';
+import {createCommitNodes} from '../algorithms/preprocess';
+import {css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {styleMap} from 'lit/directives/style-map';
+import 'vscode-elements/main'; // go/lit-style#importing-elements
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState} from '../api/types';
+import {CommitNode} from '../api/types';
+import {JjResizeController} from './resize_controller';
+
+import './commit_graph';
+
+interface StateAndNodes {
+  state: CommitGraphState;
+  // All nodes of the graph sorted by their y-coordinate in descending order.
+  sortedNodes: CommitNode[];
+}
+
+/**
+ * Root of the commit graph app.
+ */
+@customElement('jj-app')
+export class JjApp extends JjResizeController {
+  static override styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+  `;
+
+  @property({attribute: false}) extensionApi?: ExtensionShape;
+  @property({attribute: false}) states: StateAndNodes[] = [];
+
+  async setStates(states: CommitGraphState[]) {
+    this.states = [];
+    for (const state of states) {
+      const commits = state.options.disableFocusMode
+        ? getFocusedCommits(state.commits)
+        : state.commits;
+      const nodesMap = createCommitNodes(commits);
+      const sortedNodes = [...nodesMap.values()].sort((a, b) => b.y - a.y);
+      void this.extensionApi?.$informNewOrder(state.repoName, {
+        childrenOrder: sortedNodes.map((node) => ({
+          parentHash: node.hash,
+          childrenHashes: node.children.map((child) => child.node.hash),
+        })),
+        topToBottomOrder: sortedNodes.map((node) => node.hash),
+        wcCommitIndex: sortedNodes.findIndex((node) => node.active),
+      });
+      state.multiSelectionMode =
+        sortedNodes.filter((commit) => commit.isMultiSelected).length > 1;
+      state.unfocusedCommits = state.commits.length - commits.length;
+      this.states.push({
+        state,
+        sortedNodes,
+      });
+    }
+    // Wait for the next animation frame to ensure that the UI has been
+    // updated with the new states.
+    return new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        resolve();
+      });
+    });
+  }
+
+  override render() {
+    const extensionApi = this.extensionApi;
+    if (!extensionApi) {
+      return html``;
+    }
+    return html`${this.states.map(
+      ({state, sortedNodes}) =>
+        html`<jj-commit-graph
+          style=${styleMap({
+            width: this.renderedWidth ? `${this.renderedWidth}px` : '100%',
+          })}
+          .extensionApi=${extensionApi}
+          .state=${state}
+          .sortedNodes=${sortedNodes}
+          @contextmenu=${async (event: MouseEvent) => {
+            // Eat the context menu event. Otherwise VS Code shows a default
+            // Cut/Copy/Paste menu that doesn't do anything.
+            event.preventDefault();
+          }}
+        ></jj-commit-graph>`,
+    )}`;
+  }
+
+  private readonly onClick = (event: MouseEvent) => {
+    if ((event.target as HTMLElement).id !== 'jj-app') {
+      for (const state of this.states) {
+        void this.extensionApi?.$clearMultiSelection(state.state.repoName);
+      }
+    }
+  };
+
+  override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('click', this.onClick);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('click', this.onClick);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-app': JjApp;
+  }
+}

--- a/src/ui/commit_graph/components/callout.ts
+++ b/src/ui/commit_graph/components/callout.ts
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {classMap} from 'lit/directives/class-map';
+import {safeHTML} from './safe_html';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {Callout} from '../api/types';
+import {CalloutType} from '../api/types';
+
+@customElement('jj-callout')
+class JjCallout extends LitElement {
+  // The callout styles are based on go/cider-developing-webviews#callouts-and-warnings
+  static override styles = css`
+    a,
+    .dismiss-link {
+      color: var(
+        --vscode-inputValidation-infoForeground,
+        var(--vscode-textLink-foreground)
+      );
+    }
+    div.callout {
+      padding: 8px;
+      border: 1px solid var(--vscode-editorWidget-border);
+      margin: 5px;
+    }
+    div.callout-error {
+      border-color: var(--vscode-inputValidation-errorBorder);
+      background-color: var(--vscode-inputValidation-errorBackground);
+      color: var(--vscode-inputValidation-errorForeground);
+    }
+    div.callout-warning {
+      border-color: var(--vscode-inputValidation-warningBorder);
+      background-color: var(--vscode-inputValidation-warningBackground);
+      color: var(--vscode-inputValidation-warningForeground);
+    }
+    div.callout-info {
+      border-color: var(--vscode-inputValidation-infoBorder);
+      background-color: var(--vscode-inputValidation-infoBackground);
+      color: var(--vscode-inputValidation-infoForeground);
+    }
+    h1 {
+      font-weight: bold;
+      font-size: calc(var(--vscode-font-size) * 1.1);
+    }
+    ul {
+      margin: 0;
+    }
+    .dismiss-link {
+      margin-top: 10px;
+    }
+    .dismiss-link span:hover {
+      cursor: pointer;
+      text-decoration: underline;
+    }
+  `;
+
+  @property({attribute: false}) callout?: Callout;
+  @property({attribute: false}) extensionApi?: ExtensionShape;
+
+  override render() {
+    if (this.callout === undefined) {
+      return html``;
+    }
+    const classes = classMap({
+      callout: true,
+      'callout-error': this.callout.type === CalloutType.ERROR,
+      'callout-warning': this.callout.type === CalloutType.WARNING,
+      'callout-info': this.callout.type === CalloutType.INFO,
+    });
+    return html`<div class=${classes}>
+      ${safeHTML(this.callout.message)}${this.renderDismissButton()}
+    </div>`;
+  }
+
+  private dismissCallout() {
+    void this.extensionApi?.$dismissCallout(this.callout!.dismissId!);
+    this.callout = undefined;
+    this.requestUpdate();
+  }
+
+  private renderDismissButton() {
+    if (!this.callout?.dismissId) {
+      return html``;
+    }
+    if (this.callout.dismissStyle === 'link') {
+      return html`<div class="dismiss-link">
+        <span
+          @click=${() => {
+            this.dismissCallout();
+          }}
+          >Don't show this again
+        </span>
+      </div>`;
+    }
+    return html`<vscode-button
+      @click=${() => {
+        this.dismissCallout();
+      }}
+      >Dismiss</vscode-button
+    >`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-callout': JjCallout;
+  }
+}

--- a/src/ui/commit_graph/components/codicon.ts
+++ b/src/ui/commit_graph/components/codicon.ts
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {styleMap} from 'lit/directives/style-map';
+
+@customElement('jj-codicon')
+class JjCodicon extends LitElement {
+  static override styles = [
+    css`
+      :host {
+        width: 16px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      .codicon {
+        color: var(--vscode-foreground);
+      }
+    `,
+  ];
+
+  // Required. The codicon to display.
+  @property({attribute: false}) codicon!: string;
+
+  // Optional. If set, the codicon will be rendered with the given color.
+  @property({attribute: false}) color?: string;
+
+  override render() {
+    if (this.codicon === 'codicon-checkout') {
+      return html`<jj-edit-codicon></jj-edit-codicon>`;
+    }
+    let codicon = this.codicon;
+    if (codicon.startsWith('codicon-')) {
+      codicon = codicon.slice('codicon-'.length);
+    }
+    const styles = styleMap({
+      color: this.color,
+    });
+    return html`<vscode-icon name="${codicon}" style=${styles}></vscode-icon>`;
+  }
+}
+
+@customElement('jj-edit-codicon')
+class JjEditCodicon extends LitElement {
+  override render() {
+    return html`
+      <svg
+        viewBox="0 -1 16 15"
+        width="16"
+        height="16"
+        stroke="currentColor"
+        fill="currentColor"
+      >
+        <line x1="3.5" y1="6.4" x2="3.5" y2="1" stroke-width="1"></line>
+        <line x1="3.5" y1="10.1" x2="3.5" y2="15" stroke-width="1"></line>
+        <circle cx="3.5" cy="8.5" r="2.1" stroke-width="1" fill="none"></circle>
+        <path
+          d="M13.23 1h-1.46L3.52 9.25l-.16.22L1 13.59 2.41 15l4.12-2.36.22-.16L15 4.23V2.77L13.23 1zM2.41 13.59l1.51-3 1.45 1.45-2.96 1.55zm3.83-2.06L4.47 9.76l8-8 1.77 1.77-8 8z"
+          stroke="none"
+          transform="scale(0.7) translate(8, 0)"
+        ></path>
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-codicon': JjCodicon;
+    'jj-edit-codicon': JjEditCodicon;
+  }
+}

--- a/src/ui/commit_graph/components/commit_graph.ts
+++ b/src/ui/commit_graph/components/commit_graph.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState} from '../api/types';
+import {CommitNode} from '../api/types';
+import {createCommitTarget} from './drag_and_drop_state';
+
+import './callout';
+import './codicon';
+import './commit_row';
+import './focus_mode_text';
+import './top_bar';
+
+@customElement('jj-commit-graph')
+class JjCommitGraph extends LitElement {
+  static override styles = css`
+    .repo-name-with-codicon {
+      display: flex;
+      gap: 5px;
+      align-items: center;
+      padding-left: 5px;
+      padding-bottom: 3px;
+    }
+    .repo-name {
+      font-weight: bold;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
+    }
+  `;
+
+  // All nodes of the graph sorted by their y-coordinate in descending order.
+  @property({attribute: false}) sortedNodes: CommitNode[] = [];
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  override render() {
+    return html`${this.renderRepoName()}${this.renderTopBar()}${this.renderCallouts()}
+      <div>${this.renderCommitRows()}</div>
+      <jj-focus-mode-text
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+      ></jj-focus-mode-text>`;
+  }
+
+  private renderRepoName() {
+    if (this.state.repoName === undefined) {
+      return html``;
+    }
+    return html`<div class="repo-name-with-codicon">
+      <jj-codicon .codicon=${'codicon-repo'}></jj-codicon>
+      <div class="repo-name">${this.state.repoName}</div>
+    </div>`;
+  }
+
+  private renderTopBar() {
+    if (
+      !this.state ||
+      !this.extensionApi ||
+      this.state.topBarButtons.length === 0
+    ) {
+      return html``;
+    }
+    return html`<jj-top-bar
+      .extensionApi=${this.extensionApi}
+      .state=${this.state}
+    ></jj-top-bar> `;
+  }
+
+  private renderCallouts() {
+    return html`${this.state.callouts.map(
+      (callout) =>
+        html`<jj-callout
+          .callout=${callout}
+          .extensionApi=${this.extensionApi}
+        ></jj-callout>`,
+    )}`;
+  }
+
+  private renderCommitRows() {
+    return html`${this.sortedNodes.map(
+      (node) =>
+        html`<jj-commit-row
+          .extensionApi=${this.extensionApi}
+          .state=${this.state}
+          .node=${node}
+          .nodes=${this.sortedNodes}
+          .subscribedTarget=${createCommitTarget(node)}
+        >
+        </jj-commit-row>`,
+    )}`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-graph': JjCommitGraph;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row.ts
+++ b/src/ui/commit_graph/components/commit_row.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html} from 'lit';
+import {customElement, property, state} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode} from '../api/types';
+import {openContextMenu} from '../components/context_menu_provider';
+import {JjCommitRowDisplayId} from './commit_row_display_id';
+import {JjCommitRowLeftSide} from './commit_row_left_side';
+import {isDraggable} from './drag_and_drop_publisher';
+import {createCommitTarget} from './drag_and_drop_state';
+import {JjDragAndDropSubscriber} from './drag_and_drop_subscriber';
+
+import './commit_row_display_id';
+import './commit_row_left_side';
+import './commit_row_right_side';
+import './drag_and_drop_publisher';
+
+@customElement('jj-commit-row')
+class JjCommitRow extends JjDragAndDropSubscriber {
+  static override styles = css`
+    .commit-row {
+      display: flex;
+      flex-direction: row;
+      padding: 0px;
+      padding-left: 7px;
+      padding-right: 5px;
+    }
+    .commit-row:hover {
+      background-color: var(--vscode-list-hoverBackground);
+      cursor: pointer;
+    }
+    .commit-row[isInactivelySelected] {
+      background-color: var(--vscode-list-inactiveSelectionBackground);
+    }
+    .commit-row[isActivelySelected] {
+      background-color: var(--jj-activeCommitRow-background);
+      color: var(--jj-activeCommitRow-foreground);
+    }
+    .commit-row[isDragDestination] {
+      background-color: var(--vscode-list-dropBackground);
+      color: var(--vscode-foreground);
+    }
+    jj-commit-row-left-side {
+      position: absolute;
+    }
+    jj-drag-and-drop-publisher {
+      flex-grow: 1;
+      overflow: hidden;
+    }
+  `;
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) nodes!: CommitNode[];
+
+  @state() isHovered = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('mouseenter', () => (this.isHovered = true));
+    this.addEventListener('mouseleave', () => (this.isHovered = false));
+  }
+
+  override render() {
+    const displayIdWidth = JjCommitRowDisplayId.getWidth(
+      this.nodes,
+      this.state.options,
+    );
+    const graphWidth = JjCommitRowLeftSide.getWidth(this.node);
+
+    const target = createCommitTarget(this.node);
+    return html`
+      <div
+        class="commit-row"
+        title=${this.node.fullDescription}
+        ?isInactivelySelected=${this.node.active ?? false}
+        ?isActivelySelected=${this.node.isMultiSelected}
+        ?isDragDestination=${this.isDragDestination}
+        @click=${(event: MouseEvent) => {
+          if (event.defaultPrevented) {
+            // This is a workaround for the fact that vs code webviews don't
+            // allow calling event.stopPropagation on the click event.
+            // See commit_row_chip.ts for more details.
+            return;
+          }
+          void this.extensionApi.$onClick(
+            this.state.repoName,
+            this.node.hash,
+            /*metaKey=*/ event.metaKey || event.ctrlKey,
+            /*shiftKey=*/ event.shiftKey,
+          );
+        }}
+        @dblclick=${(event: MouseEvent) => {
+          if (event.metaKey || event.ctrlKey) {
+            return;
+          }
+          if (this.node.dblClick) {
+            void this.extensionApi.$executeCommand(
+              this.state.repoName,
+              this.node.dblClick.command,
+              this.node.dblClick.arguments,
+            );
+          }
+        }}
+        @contextmenu=${async (event: MouseEvent) => {
+          await this.openContextMenu(event);
+        }}
+      >
+        ${this.renderDisplayId()}
+        <jj-commit-row-left-side
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .node=${this.node}
+          style="margin-left: ${displayIdWidth}px"
+        >
+        </jj-commit-row-left-side>
+        <jj-drag-and-drop-publisher
+          .publishedTarget=${target}
+          .extensionApi=${this.extensionApi}
+          .state=${this.state}
+          class="drag-and-drop-publisher"
+        >
+          <jj-commit-row-right-side
+            class="commit-row-right-side"
+            .isDraggable=${isDraggable(target, this.state)}
+            .extensionApi=${this.extensionApi}
+            .node=${this.node}
+            .isHovered=${this.isHovered}
+            .state=${this.state}
+            .openContextMenu=${this.openContextMenu}
+            style="margin-left: ${graphWidth}px"
+          >
+          </jj-commit-row-right-side>
+        </jj-drag-and-drop-publisher>
+      </div>
+    `;
+  }
+
+  private async openContextMenu(event: MouseEvent) {
+    // Beware, this informCallContextMenuWillOpen cannot be removed even
+    // though it's no longer used by any callers.
+    // When it is removed, sometimes the context menu will not show up.
+    // It's unclear whether this is a bug in our context_menu_provider.ts,
+    // or a bug in vscode's context menu implementation, or maybe something
+    // else entirely.
+    await this.extensionApi.$informContextMenuWillOpen(
+      this.state.repoName,
+      this.node.hash,
+    );
+    if (this.state.multiSelectionMode && this.node.isMultiSelected) {
+      openContextMenu({
+        dataVscodeContext:
+          '{"origin": "commitRowMultiSelected", "preventDefaultContextMenuItems": true}',
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
+    } else {
+      openContextMenu({
+        dataVscodeContext: JSON.stringify({
+          ...(this.node.vscodeContext ?? {}),
+          origin: 'commitRow',
+          preventDefaultContextMenuItems: true,
+        }),
+        clientX: event.clientX,
+        clientY: event.clientY,
+      });
+    }
+    event.preventDefault();
+  }
+
+  private renderDisplayId() {
+    if (this.state.options.showChangeId) {
+      return html`
+        <jj-commit-row-display-id
+          .extensionApi=${this.extensionApi}
+          .state=${this.state}
+          .node=${this.node}
+          .nodes=${this.nodes}
+        >
+        </jj-commit-row-display-id>
+      `;
+    }
+    return html``;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row': JjCommitRow;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_bookmarks.ts
+++ b/src/ui/commit_graph/components/commit_row_bookmarks.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {
+  CommitGraphState,
+  CommitNode,
+  SplitBookmarkChip,
+} from '../api/types';
+import {createBookmarkTarget} from './drag_and_drop_state';
+import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
+
+import './commit_row_chip';
+import './drag_and_drop_publisher';
+
+@customElement('jj-commit-row-bookmarks')
+class JjCommitRowBookmarks extends JjDragAndDropAllTargetsSubscriber {
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) node!: CommitNode;
+
+  static override styles = css`
+    :host {
+      display: flex;
+      gap: 3px;
+    }
+  `;
+
+  override render() {
+    return html`${this.renderDraggedBookmark()}
+    ${this.node.bookmarkChips.map(
+      (chip) =>
+        html`<jj-commit-row-draggable-bookmark
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .node=${this.node}
+          .chip=${chip}
+        >
+        </jj-commit-row-draggable-bookmark>`,
+    )}`;
+  }
+
+  private renderDraggedBookmark() {
+    if (
+      this.dragged?.type !== 'bookmark' ||
+      this.dragged.data.node === this.node
+    ) {
+      return html``;
+    }
+    let hoveredNode: CommitNode;
+    if (this.hovered?.type === 'commit') {
+      hoveredNode = this.hovered.data;
+    } else if (this.hovered?.type === 'bookmark') {
+      hoveredNode = this.hovered.data.node;
+    } else {
+      return html``;
+    }
+    if (hoveredNode === this.node) {
+      return html`
+        <jj-commit-row-bookmark
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .chip=${this.dragged.data.chip}
+        >
+        </jj-commit-row-bookmark>
+      `;
+    }
+    return html``;
+  }
+}
+
+@customElement('jj-commit-row-draggable-bookmark')
+class JjCommitRowDraggableBookmark extends JjDragAndDropAllTargetsSubscriber {
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) chip!: SplitBookmarkChip;
+
+  override render() {
+    const isDragSource =
+      this.dragged?.type === 'bookmark' && this.dragged.data.chip === this.chip;
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${createBookmarkTarget(this.node, this.chip)}
+        .extensionApi=${this.extensionApi}
+        .state=${this.state}
+      >
+        <jj-commit-row-bookmark
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .chip=${this.chip}
+          .style=${`opacity: ${isDragSource ? 0.3 : 1}`}
+          draggable="true"
+        >
+        </jj-commit-row-bookmark>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-bookmarks': JjCommitRowBookmarks;
+    'jj-commit-row-draggable-bookmark': JjCommitRowDraggableBookmark;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_chip.ts
+++ b/src/ui/commit_graph/components/commit_row_chip.ts
@@ -1,0 +1,331 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property, state} from 'lit/decorators';
+import {ifDefined} from 'lit/directives/if-defined';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {
+  BookmarkChip,
+  CommitGraphState,
+  SplitBookmarkChip,
+} from '../api/types';
+import {openContextMenu} from '../components/context_menu_provider';
+import {isMac} from './user_agent';
+
+import './codicon';
+
+/**
+ * A component that renders a single bookmark chip.
+ */
+@customElement('jj-commit-row-bookmark')
+export class JjCommitRowBookmark extends LitElement {
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) chip!: SplitBookmarkChip;
+  @property({attribute: false}) opacity!: string;
+
+  static override styles = css`
+    :host {
+      display: flex;
+    }
+  `;
+
+  override render() {
+    if (this.chip.right) {
+      return html`
+        <jj-commit-row-split-chip
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .chip=${this.chip}
+          style="opacity: ${this.opacity};"
+          @contextmenu=${this.openContextMenu}
+        >
+        </jj-commit-row-split-chip>
+      `;
+    }
+    return html`
+      <jj-commit-row-chip
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        .chip=${this.chip.left}
+        style="opacity: ${this.opacity};"
+        @contextmenu=${this.openContextMenu}
+      >
+      </jj-commit-row-chip>
+    `;
+  }
+
+  private readonly openContextMenu = (event: MouseEvent) => {
+    if (this.chip.vscodeContext === undefined) {
+      return;
+    }
+    // Stop the event from bubbling up and triggering the context menu for the
+    // commit row to open.
+    event.stopPropagation();
+    // Prevent the browser default (i.e. non-vscode) context menu from opening.
+    event.preventDefault();
+    openContextMenu({
+      dataVscodeContext: JSON.stringify({
+        ...this.chip.vscodeContext,
+        origin: 'bookmarkChip',
+        preventDefaultContextMenuItems: true,
+      }),
+      clientX: event.clientX,
+      clientY: event.clientY,
+    });
+  };
+}
+
+@customElement('jj-commit-row-split-chip')
+class JjCommitRowSplitChip extends LitElement {
+  static override styles = css`
+    .wrapper {
+      display: flex;
+      flex-direction: row;
+      border-width: 1px;
+      border-style: solid;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+  `;
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) chip!: SplitBookmarkChip;
+
+  override render() {
+    return html`
+      <div
+        class="wrapper"
+        style="border-color: ${this.chip.right?.borderColor ?? 'transparent'};"
+      >
+        <jj-commit-row-chip-content
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .chip=${this.chip.left}
+        >
+        </jj-commit-row-chip-content>
+        ${this.chip.right
+          ? html`<jj-commit-row-chip-content
+              .state=${this.state}
+              .extensionApi=${this.extensionApi}
+              .chip=${this.chip.right.chip}
+            >
+            </jj-commit-row-chip-content>`
+          : html``}
+      </div>
+    `;
+  }
+}
+
+@customElement('jj-commit-row-chip')
+class JjCommitRowChip extends LitElement {
+  static override styles = css`
+    .wrapper {
+      border-width: 1px;
+      border-style: solid;
+      border-radius: 8px;
+      overflow: hidden;
+      padding: 0 2px;
+    }
+  `;
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) chip!: BookmarkChip;
+
+  override render() {
+    return html`<div
+      class="wrapper"
+      style="
+        border-color: ${this.chip.color.border};
+        background-color: ${this.chip.color.background};
+      "
+    >
+      <jj-commit-row-chip-content
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        .chip=${{
+          ...this.chip,
+          color: {
+            ...this.chip.color,
+            // Don't set the background color again, otherwise colors with
+            // transparency will overlap and show a darker color.
+            background: 'transparent',
+          },
+        }}
+      >
+      </jj-commit-row-chip-content>
+    </div>`;
+  }
+}
+
+@customElement('jj-commit-row-chip-content')
+class JjCommitRowChipContent extends LitElement {
+  static override styles = css`
+    .chip {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 18px;
+      line-height: 17px;
+      padding: 0 4px;
+      gap: 2px;
+
+      flex-grow: 1;
+
+      /** Don't allow selecting text in the chip. */
+      user-select: none;
+    }
+    .chip[underlineOnHover]:hover {
+      text-decoration: underline;
+    }
+    a {
+      text-decoration: none;
+      display: flex;
+    }
+    span[cursorPointer] {
+      cursor: pointer;
+    }
+  `;
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) chip!: BookmarkChip;
+
+  @state() isHovered = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener('mouseenter', () => (this.isHovered = true));
+    this.addEventListener('mouseleave', () => (this.isHovered = false));
+  }
+
+  override render() {
+    const command = this.chip.command;
+    if (command !== undefined) {
+      return html`<span
+        .style="min-width: ${this.chip.minWidth ?? 0}px;"
+        ?cursorPointer=${Boolean(this.chip.link || this.chip.command)}
+        @click=${(event: MouseEvent) => {
+          // Prevent parent elements from considering clicking bookmark
+          // chips as multi-select events.
+          event.stopPropagation();
+          void this.extensionApi.$executeCommand(
+            this.state.repoName,
+            command.command,
+            command.arguments,
+          );
+        }}
+      >
+        ${this.renderChip()}
+      </span>`;
+    }
+    if (this.chip.link !== undefined) {
+      return html`<a
+        .style="min-width: ${this.chip.minWidth ?? 0}px;"
+        draggable="false"
+        href="${this.chip.link ?? ''}"
+        @auxclick=${(event: MouseEvent) => {
+          // When event.button === 1, it's a mouse middle click.
+          if (event.button === 1) {
+            // Convert it to normal ctrl+click so that it opens the link in a
+            // new tab.
+            event.currentTarget?.dispatchEvent(
+              new MouseEvent('click', {
+                button: 0,
+                metaKey: true,
+                ctrlKey: true,
+                bubbles: true,
+                cancelable: true,
+              }),
+            );
+            event.stopPropagation();
+          }
+        }}
+        @click=${(event: MouseEvent) => {
+          const isMacOs = isMac();
+          if ((isMacOs && event.metaKey) || (!isMacOs && event.ctrlKey)) {
+            // Prevent parent elements from considering clicking bookmark
+            // chips as multi-select events.
+            event.stopPropagation();
+            // If we were to do event.preventDefault() here, the ctrl+click
+            // (or meta+click on Mac) would switch focus to the newly opened
+            // tab. So let's stop propagation to keep the original behavior.
+          } else {
+            // Normally we'd want to use `event.stopPropagation()` here just like
+            // above to prevent parent elements from considering the click as
+            // a multi-select event. However, VS Code has certain limitations
+            // that prevent us from doing that. In order to ensure the links
+            // from webviews are safe, VS Code intercepts click events from the
+            // webview, and has its own logic to open links. If we use
+            // `event.stopPropagation()` here, this causes VS Code to be unable
+            // to intercept the click event. As a result, the browser default
+            // behavior kicks in and opens the link inside the webview. This
+            // causes the browser Content Security Policy to kick in, and the
+            // webview is destroyed with an error message saying:
+            //      Refused to frame 'https://<the-href-link>' because it violates the following
+            //      Content Security Policy directive: "frame-src 'self' blob: https://*.scf.usercontent.goog/".
+            // To work around this, we don't call `event.stopPropagation()`,
+            // but instead call `event.preventDefault()`. In the parent element,
+            // we check whether event.defaultPrevented is true, and if so, we
+            // disregard the click event.
+            event.preventDefault();
+          }
+        }}
+      >
+        ${this.renderChip()}
+      </a>`;
+    }
+    return this.renderChip();
+  }
+
+  private renderChip() {
+    return html`<span
+      class="chip"
+      ?underlineOnHover=${this.chip.underlineOnHover ?? false}
+      title=${ifDefined(this.chip.tooltip)}
+      style="
+      background-color: ${this.chip.color.background};
+      color: ${this.chip.color.foreground};
+      white-space: nowrap;
+    "
+    >
+      ${this.renderCodicon(this.chip.codiconBefore, this.chip.color.foreground)}
+      ${this.isHovered && this.chip.textOnHover
+        ? this.chip.textOnHover
+        : this.chip.text}
+      ${this.renderCodicon(this.chip.codiconAfter, this.chip.color.foreground)}
+    </span>`;
+  }
+
+  private renderCodicon(codicon: string | undefined, color: string) {
+    if (codicon === undefined) {
+      return html``;
+    }
+    return html` <jj-codicon .codicon=${codicon} .color=${color}></jj-codicon>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-chip': JjCommitRowChip;
+    'jj-commit-row-split-chip': JjCommitRowSplitChip;
+    'jj-commit-row-chip-content': JjCommitRowChipContent;
+    'jj-commit-row-bookmark': JjCommitRowBookmark;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_display_id.ts
+++ b/src/ui/commit_graph/components/commit_row_display_id.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode} from '../api/types';
+import {CommitGraphOptions} from '../api/types';
+import {COMMIT_ROW_CHILD_ELEMENTS_GAP} from './constants';
+import {isDraggable} from './drag_and_drop_publisher';
+import {createCommitTarget} from './drag_and_drop_state';
+
+/**
+ * The display id of a commit row.
+ */
+@customElement('jj-commit-row-display-id')
+export class JjCommitRowDisplayId extends LitElement {
+  static override styles = css`
+    .highlighted-text:not([isMultiSelected]) {
+      color: var(--commit-row-highlighted-text);
+    }
+    .display-id {
+      gap: 0px;
+      padding-top: 5px;
+      /**
+       * In most font-families like sans-serif, characters have uneven
+       * width. e.g. 'm' is much wider than 'l'. This makes the total width
+       * of the display id uneven. To fix that, we use monospace font
+       * which has equal width for all characters. This makes the display id
+       * look more balanced.
+       */
+      font-family: monospace;
+      /**
+       * Taking the full height, so there are no gaps when dragging and
+       * hovering over the display id.
+       */
+      height: 100%;
+      /** Disable text selection. */
+      user-select: none;
+    }
+    .display-id * {
+      /** Avoids firing drag-leave events when hovering over child elements */
+      pointer-events: none;
+    }
+    b {
+      font-weight: 600;
+    }
+  `;
+
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) nodes!: CommitNode[];
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  override render() {
+    const width = JjCommitRowDisplayId.getWidth(this.nodes, this.state.options);
+    const target = createCommitTarget(this.node);
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${target}
+        .extensionApi=${this.extensionApi}
+        .state=${this.state}
+        class="drag-and-drop-publisher"
+      >
+        <div
+          class="display-id"
+          draggable="${isDraggable(target, this.state)}"
+          style="width: ${width}px"
+        >
+          <b
+            class="highlighted-text"
+            ?isMultiSelected=${this.node.isMultiSelected}
+            >${this.node.displayId.substring(
+              0,
+              this.node.highlightedDisplayIdLen,
+            )}</b
+          >${this.node.displayId.substring(this.node.highlightedDisplayIdLen)}
+        </div>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+
+  static getWidth(nodes: CommitNode[], options: CommitGraphOptions): number {
+    if (!options.showChangeId) {
+      return 0;
+    }
+    let maxCharacters = 0;
+    for (const node of nodes) {
+      maxCharacters = Math.max(maxCharacters, node.displayId.length);
+    }
+    return (
+      maxCharacters * 7.5 * (options.uiScaling ?? 1) +
+      COMMIT_ROW_CHILD_ELEMENTS_GAP
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-display-id': JjCommitRowDisplayId;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_left_side.ts
+++ b/src/ui/commit_graph/components/commit_row_left_side.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode} from '../api/types';
+import {COMMIT_ROW_CHILD_ELEMENTS_GAP, TILE_WIDTH} from './constants';
+
+import './tile_group';
+
+/**
+ * The left side of a commit row, which includes the commit graph lines and
+ * the commit node.
+ */
+@customElement('jj-commit-row-left-side')
+export class JjCommitRowLeftSide extends LitElement {
+  static override styles = css`
+    .commit-row-left-side {
+      display: flex;
+      flex-direction: row;
+      height: 100%;
+    }
+  `;
+
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  override render() {
+    const node = this.node;
+    const tiles = [];
+    for (let x = 0; x < node.tileGroups.length; ++x) {
+      tiles.push(
+        html`<jj-tile-group
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .tileGroup=${node.tileGroups[x]}
+          .node=${node}
+          .x=${x}
+        >
+        </jj-tile-group>`,
+      );
+    }
+    return html`<div class="commit-row-left-side">${tiles}</div> `;
+  }
+
+  static getWidth(node: CommitNode) {
+    return TILE_WIDTH * node.occupiedColumns + COMMIT_ROW_CHILD_ELEMENTS_GAP;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-left-side': JjCommitRowLeftSide;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_right_side.ts
+++ b/src/ui/commit_graph/components/commit_row_right_side.ts
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {ifDefined} from 'lit/directives/if-defined';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode} from '../api/types';
+import {MERGE_TILE_HEIGHT, TILE_HEIGHT} from './constants';
+
+import './commit_row_title';
+import './drag_and_drop_publisher';
+
+@customElement('jj-commit-row-right-side')
+class JjCommitRowRightSide extends LitElement {
+  static override get styles() {
+    return css`
+      :host {
+        display: flex;
+        position: relative;
+        flex-direction: column;
+      }
+      .commit-row-right-side {
+        display: flex;
+        padding: 0px;
+        width: calc(100% - 3px);
+        height: 100%;
+        flex-direction: row;
+      }
+      .button-group-wrapper {
+        height: ${TILE_HEIGHT + 2 * MERGE_TILE_HEIGHT}px;
+      }
+      .button-group {
+        display: flex;
+        flex-grow: 1;
+        flex-direction: row;
+        height: 100%;
+        gap: 1px;
+        background-color: transparent;
+        align-items: center;
+      }
+      .button-group[shouldHide] {
+        display: none;
+      }
+      vscode-icon[isActivelySelected] {
+        color: var(--vscode-list-activeSelectionForeground);
+      }
+    `;
+  }
+
+  @property({attribute: false}) isDraggable!: boolean;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) isHovered!: boolean;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) openContextMenu!: (event: MouseEvent) => void;
+
+  override render() {
+    return html`
+      <div class="commit-row-right-side" draggable="${this.isDraggable}">
+        <jj-commit-row-title
+          .extensionApi=${this.extensionApi}
+          .state=${this.state}
+          .node=${this.node}
+        >
+        </jj-commit-row-title>
+        <div class="button-group-wrapper">${this.renderIconButtons()}</div>
+      </div>
+    `;
+  }
+
+  private renderIconButtons() {
+    const buttons = (this.node.iconButtons ?? []).map((button) => {
+      return html`
+        <vscode-icon
+          name=${button.icon}
+          title=${ifDefined(button.command.tooltip)}
+          ?isActivelySelected=${this.node.isMultiSelected}
+          action-icon
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            void this.extensionApi.$executeCommand(
+              this.state.repoName,
+              button.command.command,
+              button.command.arguments,
+            );
+          }}
+        ></vscode-icon>
+      `;
+    });
+    const contextMenuButton = html`
+      <vscode-icon
+        name="kebab-vertical"
+        title="More"
+        ?isActivelySelected=${this.node.isMultiSelected}
+        action-icon
+        @click=${(event: MouseEvent) => {
+          this.openContextMenu(event);
+        }}
+      ></vscode-icon>
+    `;
+    return html`
+      <div
+        class="button-group"
+        ?shouldHide=${!this.isHovered && !this.state.options.alwaysShowActions}
+      >
+        ${buttons}
+        ${this.state.options.showContextMenuIcon ? contextMenuButton : ''}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-right-side': JjCommitRowRightSide;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_title.ts
+++ b/src/ui/commit_graph/components/commit_row_title.ts
@@ -1,0 +1,153 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {checkExhaustive} from '../utils/check';
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode} from '../api/types';
+import {CommitMetadataTextStyle} from '../api/types';
+
+import './commit_row_bookmarks';
+import './commit_row_chip';
+import './time_ago_text';
+
+@customElement('jj-commit-row-title')
+class JjCommitRowTitle extends LitElement {
+  static override styles = css`
+    :host {
+      display: flex;
+      gap: 3px;
+      width: 100%;
+      overflow: hidden;
+      align-items: center;
+    }
+    .title {
+      display: flex;
+      gap: 3px;
+      white-space: nowrap;
+      flex-grow: 1;
+      overflow: hidden;
+    }
+    .warning-text {
+      color: var(--vscode-editorError-foreground);
+    }
+    .highlighted-text:not([isMultiSelected]) {
+      color: var(--commit-row-highlighted-text);
+    }
+    .working-copy-text:not([isMultiSelected]) {
+      color: var(--vscode-editorInfo-foreground);
+    }
+    .description-title-text {
+      text-overflow: ellipsis;
+      overflow: hidden;
+    }
+  `;
+
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  override render() {
+    return html`
+      <jj-commit-row-bookmarks
+        .node=${this.node}
+        .extensionApi=${this.extensionApi}
+        .state=${this.state}
+      >
+      </jj-commit-row-bookmarks>
+      <div class="title">
+        ${this.renderConflictText()} ${this.renderDivergentText()}
+        ${this.renderCommitMetadataText()} ${this.renderShortDescription()}
+      </div>
+    `;
+  }
+
+  private renderConflictText() {
+    if (this.node.hasConflict) {
+      return html` <span class="warning-text">conflict</span> `;
+    }
+    return html``;
+  }
+
+  private renderDivergentText() {
+    if (this.node.hasDiverged) {
+      return html` <span class="warning-text">divergent</span> `;
+    }
+    return html``;
+  }
+
+  private renderCommitMetadataText() {
+    const text = [];
+
+    const isEmpty = this.node.isEmpty;
+    const noDescriptionSet = this.node.shortDescription.length === 0;
+
+    switch (this.state.options.commitMetadataTextStyle) {
+      case undefined:
+      case CommitMetadataTextStyle.SHOW_EMPTY_AND_NO_DESCRIPTION_SET:
+        if (isEmpty) {
+          text.push(this.renderHighlightedText('(empty)'));
+        }
+        if (noDescriptionSet) {
+          text.push(this.renderHighlightedText('(no description set)'));
+        }
+        break;
+      case CommitMetadataTextStyle.SHOW_EMPTY_AND_HAS_CHANGES:
+        if (isEmpty && noDescriptionSet) {
+          break;
+        } else if (isEmpty) {
+          text.push(this.renderHighlightedText('(empty)'));
+        } else if (noDescriptionSet) {
+          text.push(this.renderHighlightedText('(has changes)'));
+        }
+        break;
+      default:
+        checkExhaustive(this.state.options.commitMetadataTextStyle);
+    }
+    return html`${text}`;
+  }
+
+  private renderHighlightedText(text: string) {
+    return html`
+      <span
+        class="highlighted-text"
+        ?isMultiSelected=${this.node.isMultiSelected}
+        >${text}</span
+      >
+    `;
+  }
+
+  private renderShortDescription() {
+    if (this.node.isImmutable) {
+      return html`<jj-time-ago-text
+        class="description-title-text"
+        .text=${this.state.timeAgoTitle}
+        .node=${this.node}
+      >
+      </jj-time-ago-text>`;
+    }
+    return html`<div class="description-title-text">
+      ${this.node.shortDescription}
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-title': JjCommitRowTitle;
+  }
+}

--- a/src/ui/commit_graph/components/constants.ts
+++ b/src/ui/commit_graph/components/constants.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The width of a tile in the graph.
+ */
+export const TILE_WIDTH = 14;
+
+/**
+ * The height of a tile in the graph.
+ */
+export const TILE_HEIGHT = 14;
+
+/**
+ * The radius of a circle in the graph.
+ */
+export const CIRCLE_RADIUS = 5;
+
+/**
+ * The stroke width of a line in the graph.
+ */
+export const STROKE_WIDTH = 1.5;
+
+/**
+ * The height of the top or bottom tiles in the graph.
+ */
+export const MERGE_TILE_HEIGHT = 5;
+
+/**
+ * The height of a commit row in the graph.
+ */
+export const COMMIT_ROW_HEIGHT = TILE_HEIGHT + 2 * MERGE_TILE_HEIGHT;
+
+/**
+ * The height of the top bar in the graph.
+ */
+export const TOP_BAR_HEIGHT = 35;
+
+/**
+ * The gap between the child elements of a commit row.
+ */
+export const COMMIT_ROW_CHILD_ELEMENTS_GAP = 4;

--- a/src/ui/commit_graph/components/context_menu_provider.ts
+++ b/src/ui/commit_graph/components/context_menu_provider.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators';
+
+/**
+ * Opens the context menu at the given coordinates.
+ */
+export function openContextMenu(options: {
+  dataVscodeContext: string;
+  clientX: number;
+  clientY: number;
+}) {
+  const target = document.getElementById('jj-context-menu-provider');
+  if (target === null) {
+    return;
+  }
+  target.setAttribute('data-vscode-context', options.dataVscodeContext);
+  target.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      clientX: options.clientX,
+      clientY: options.clientY,
+    }),
+  );
+}
+
+@customElement('jj-context-menu-provider')
+class JjContextMenuProvider extends LitElement {
+  override render() {
+    return html`
+      <button id="jj-context-menu-provider" style="display: none"></button>
+    `;
+  }
+
+  override createRenderRoot() {
+    return this;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-context-menu-provider': JjContextMenuProvider;
+  }
+}

--- a/src/ui/commit_graph/components/drag_and_drop_publisher.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_publisher.ts
@@ -1,0 +1,321 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {checkExhaustive} from '../utils/check';
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {classMap} from 'lit/directives/class-map';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {
+  CommitGraphState,
+  CommitNode,
+  SplitBookmarkChip,
+} from '../api/types';
+import {JjCommitRowBookmark} from './commit_row_chip';
+import type {Target} from './drag_and_drop_state';
+import {getManager, isNoopInsert} from './drag_and_drop_state';
+
+/**
+ * A component that enables dragging and dropping of its children.
+ *
+ * Once wrapped in this component, the children of this component will be
+ * draggable, and dragging them will trigger events sent to the
+ * DragAndDropStateManager.
+ *
+ * Any element that intends to react to such drag and drop events should extend
+ * JjDragAndDropSubscriber. See drag_and_drop_subscriber.ts for more details.
+ *
+ * Usage:
+ * <jj-drag-and-drop-publisher>
+ *   <your-component draggable="${isDraggable(...)}"></your-component>
+ * </jj-drag-and-drop-publisher>
+ */
+@customElement('jj-drag-and-drop-publisher')
+class JjDragAndDropPublisher extends LitElement {
+  // If defined, any drag and drop events to this LitElement will be associated
+  // with this target. If undefined, dragging and dropping will be disabled.
+  @property({attribute: false}) publishedTarget?: Target;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  static override styles = css`
+    :host {
+      height: 100%;
+    }
+    div {
+      width: 100%;
+      height: 100%;
+    }
+    .isDraggable {
+      cursor: grab;
+      width: 100%;
+    }
+  `;
+
+  override render() {
+    const target = this.publishedTarget;
+    if (target === undefined) {
+      return html`<div draggable="false"><slot></slot></div>`;
+    }
+    const classes = classMap({
+      isDraggable: isDraggable(target, this.state),
+    });
+
+    const draggable = isDraggable(target, this.state);
+    return html`
+      <div
+        class="${classes}"
+        draggable="${draggable}"
+        @dragstart=${(event: DragEvent) => {
+          if (!draggable) {
+            // The browser can still fire dragstart even if the draggable
+            // attribute is set to false.
+            event.preventDefault();
+            event.stopPropagation();
+            return;
+          }
+          let dragImage: HTMLElement | undefined;
+          switch (target.type) {
+            case 'bookmark':
+              dragImage = this.getBookmarkDragImage(target.data.chip);
+              break;
+            case 'commit':
+              dragImage = this.getBlankImage();
+              break;
+            default:
+              break;
+          }
+          if (dragImage) {
+            this.setDragImage(event, dragImage);
+          }
+
+          getManager().onDragStart(event, target);
+        }}
+        @dragend=${async (event: DragEvent) => {
+          event.stopPropagation();
+          try {
+            await this.handleDragEnd();
+          } finally {
+            getManager().onDragEnd(event);
+          }
+        }}
+        @dragenter=${(event: DragEvent) => {
+          getManager().onDragEnter(event, target);
+        }}
+        @dragleave=${(event: DragEvent) => {
+          // This is a sad but working hack.
+          // Mostly on Linux, the dragleave event is fired before the dragend
+          // event. This causes bugs like b/440334795 where the graph considers
+          // the drag as aborted since it thinks it's not hovering over any
+          // element. To fix this, we delay the dragleave event by 10ms. This is
+          // long enough to guarantee the dragend event is fired. It also does
+          // not cause a user-noticeable delay in the UI, since:
+          //   1) we already use dragenter as the signal to update the 'rebase here' bubble
+          //   2) 10 ms is pretty short
+          // Ideally, we should figure out a proper way to fix this, possibly by
+          // using @drop instead of @dragend, but I haven't been able to get that
+          // working yet.
+          setTimeout(() => {
+            getManager().onDragLeave(event, target);
+          }, 10);
+        }}
+        @dragover=${(event: DragEvent) => {
+          getManager().onDragOver(event);
+        }}
+      >
+        <slot></slot>
+      </div>
+    `;
+  }
+
+  private async handleDragEnd() {
+    const dragged = getManager().getDragged();
+    const hovered = getManager().getHovered();
+    if (dragged === undefined || hovered === undefined) {
+      return;
+    }
+    if (dragged.type === 'bookmark') {
+      const type = hovered.type;
+      const {dragAndDropCommands} = dragged.data.chip;
+      if (!dragAndDropCommands) {
+        return;
+      }
+      if (type === 'commit' || type === 'bookmark') {
+        let destinationCommit: CommitNode;
+        if (hovered.type === 'commit') {
+          destinationCommit = hovered.data;
+        } else {
+          destinationCommit = hovered.data.node;
+        }
+        if (destinationCommit === dragged.data.node) {
+          return;
+        }
+        await this.extensionApi.$executeCommand(
+          this.state.repoName,
+          dragAndDropCommands.move.command,
+          [
+            ...(dragAndDropCommands.move.arguments ?? []),
+            destinationCommit.hash,
+          ],
+        );
+      } else if (type === 'garbageSection') {
+        await this.extensionApi.$executeCommand(
+          this.state.repoName,
+          dragAndDropCommands.abandon.command,
+          dragAndDropCommands.abandon.arguments,
+        );
+      }
+    } else if (dragged.type === 'commit') {
+      const dragAndDropCommands = this.state.options.dragAndDropCommands;
+      if (!dragAndDropCommands) {
+        return;
+      }
+
+      const sourceCommits = this.state.multiSelectionMode
+        ? this.state.commits
+            .filter((commit) => commit.isMultiSelected)
+            .map((commit) => commit.hash)
+        : [dragged.data.hash];
+
+      const type = hovered.type;
+      switch (type) {
+        case 'commit':
+        case 'bookmark': {
+          const hoveredCommit =
+            hovered.type === 'commit' ? hovered.data : hovered.data.node;
+
+          await this.extensionApi.$executeCommand(
+            this.state.repoName,
+            dragAndDropCommands.rebase.command,
+            [
+              ...(dragAndDropCommands.rebase.arguments ?? []),
+              sourceCommits,
+              hoveredCommit.hash,
+            ],
+          );
+          return;
+        }
+        case 'garbageSection':
+          // Don't wait for the command to complete. Return as soon as possible,
+          // so users can start the next drag and drop operation.
+          void this.extensionApi.$executeCommand(
+            this.state.repoName,
+            dragAndDropCommands.abandon.command,
+            [...(dragAndDropCommands.abandon.arguments ?? []), sourceCommits],
+          );
+          return;
+        case 'insert': {
+          if (
+            hovered.data.from === undefined &&
+            hovered.data.to === undefined
+          ) {
+            throw new Error(
+              'Programming error: one of from or to should be defined.',
+            );
+          }
+          if (isNoopInsert(dragged, hovered)) {
+            return;
+          }
+
+          let insertBefore: string[];
+          if (hovered.data.to) {
+            insertBefore = [hovered.data.to.hash];
+          } else {
+            insertBefore = hovered.data.from.children.map(
+              (child) => child.node.hash,
+            );
+          }
+
+          let insertAfter: string[];
+          if (hovered.data.from) {
+            insertAfter = [hovered.data.from.hash];
+          } else {
+            insertAfter = hovered.data.to.parents.map((parent) => parent.hash);
+          }
+
+          await this.extensionApi.$executeCommand(
+            this.state.repoName,
+            dragAndDropCommands.insert.command,
+            [
+              ...(dragAndDropCommands.insert.arguments ?? []),
+              {
+                target: sourceCommits,
+                insertBefore,
+                insertAfter,
+              },
+            ],
+          );
+          break;
+        }
+        default:
+          checkExhaustive(type);
+      }
+    }
+  }
+
+  private getBlankImage() {
+    const blankImage = document.createElement('div');
+    blankImage.innerText = 'ghost';
+    blankImage.style.transform = 'translate(-10000px, -10000px)';
+    blankImage.style.position = 'absolute';
+    blankImage.style.visibility = 'hidden';
+    return blankImage;
+  }
+
+  private getBookmarkDragImage(chip: SplitBookmarkChip) {
+    const bookmark = new JjCommitRowBookmark();
+    bookmark.state = this.state;
+    bookmark.extensionApi = this.extensionApi;
+    bookmark.chip = chip;
+    bookmark.opacity = '0.7';
+    return bookmark;
+  }
+
+  private setDragImage(event: DragEvent, dragImage: HTMLElement) {
+    document.body.appendChild(dragImage);
+    // Set the drag image (0,0 offsets it to the cursor top-left)
+    event.dataTransfer?.setDragImage(dragImage, 0, 0);
+    // Remove the element immediately after setDragImage is called.
+    setTimeout(() => document.body.removeChild(dragImage), 0);
+  }
+}
+
+/**
+ * Returns whether the given node is draggable.
+ */
+export function isDraggable(target: Target, state: CommitGraphState) {
+  if (!state.options.dragAndDropCommands) {
+    return false;
+  }
+  if (target.type === 'garbageSection' || target.type === 'insert') {
+    return false;
+  }
+  if (target.type === 'bookmark') {
+    return Boolean(target.data.chip.dragAndDropCommands);
+  }
+
+  const commit = target.data;
+  if (state.multiSelectionMode && !commit.isMultiSelected) {
+    return false;
+  }
+  return !commit.isImmutable;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-drag-and-drop-publisher': JjDragAndDropPublisher;
+  }
+}

--- a/src/ui/commit_graph/components/drag_and_drop_state.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_state.ts
@@ -1,0 +1,311 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {checkExhaustive} from '../utils/check';
+import {CommitNode, InsertAction, SplitBookmarkChip} from '../api/types';
+import {isMac} from './user_agent';
+
+/** A callback that is called when the drag and drop state changes. */
+export type SubscriberCallback = () => void;
+
+/**  A drag and drop target. */
+export type Target =
+  | {
+      // Represents a commit.
+      type: 'commit';
+      data: CommitNode;
+    }
+  | {
+      // Represents the garbage section.
+      type: 'garbageSection';
+    }
+  | {
+      type: 'insert';
+      data: InsertAction;
+    }
+  | {
+      type: 'bookmark';
+      data: {
+        node: CommitNode;
+        chip: SplitBookmarkChip;
+      };
+    };
+
+/** Creates a target that represents a commit.  */
+export function createCommitTarget(node: CommitNode): Target {
+  return {
+    type: 'commit',
+    data: node,
+  };
+}
+
+/** Creates a target that represents an insert action. */
+export function createInsertTarget(
+  action: InsertAction | undefined,
+): Target | undefined {
+  if (action === undefined) {
+    return undefined;
+  }
+  return {
+    type: 'insert',
+    data: action,
+  };
+}
+
+/** Creates a target that represents a bookmark. */
+export function createBookmarkTarget(
+  node: CommitNode,
+  chip: SplitBookmarkChip,
+): Target {
+  return {
+    type: 'bookmark',
+    data: {node, chip},
+  };
+}
+
+/** A target that represents the garbage section. */
+export const GARBAGE_SECTION_TARGET: Target = {
+  type: 'garbageSection',
+};
+
+/**
+ * Returns whether the given targets are equal.
+ */
+export function isEqual(a: Target | undefined, b: Target | undefined) {
+  if (a === undefined || b === undefined) {
+    return a === b;
+  }
+  switch (a.type) {
+    case 'commit':
+      return b.type === 'commit' && a.data === b.data;
+    case 'garbageSection':
+      return b.type === 'garbageSection';
+    case 'insert':
+      return (
+        b.type === 'insert' &&
+        a.data.from === b.data.from &&
+        a.data.to === b.data.to
+      );
+    case 'bookmark':
+      return (
+        b.type === 'bookmark' &&
+        a.data.node === b.data.node &&
+        a.data.chip === b.data.chip
+      );
+    default:
+      checkExhaustive(a);
+  }
+}
+
+/**
+ * Returns true if `dragged` is a commit and `hovered` is an insert action, and
+ * the result of that drag is invalid or a no-op.
+ */
+export function isNoopInsert(
+  draggedTarget: Target | undefined,
+  hoveredTarget: Target | undefined,
+): boolean {
+  if (draggedTarget?.type === 'bookmark') {
+    return (
+      hoveredTarget?.type !== 'commit' ||
+      draggedTarget.data.node === hoveredTarget.data
+    );
+  }
+  if (draggedTarget?.type !== 'commit' || hoveredTarget?.type !== 'insert') {
+    return false;
+  }
+  const dragged = draggedTarget.data;
+  const {from, to} = hoveredTarget.data;
+
+  if (from === undefined && dragged === to) {
+    return true;
+  }
+  if (to === undefined && dragged === from) {
+    return true;
+  }
+
+  // It is not possible to insert a commit before an immutable commit.
+  if (
+    to?.isImmutable ||
+    (to === undefined && from?.children.some((child) => child.node.isImmutable))
+  ) {
+    return true;
+  }
+
+  return from === dragged || to === dragged;
+}
+
+/**
+ * A class that stores the current drag and drop state, and notifies subscribers
+ * when the state changes. This allows multiple elements to publish their state,
+ * and other elements to subscribe to the state and react to it.
+ */
+export class DragAndDropStateManager {
+  // The target that is currently being dragged.
+  private dragged?: Target;
+
+  // The target that is currently being hovered over.
+  private readonly hovered: Array<{
+    target: Target;
+    // HTML Drag and drop events can fire multiple enter events for the same
+    // element. e.g. We could get enter, enter, leave. This counter tracks how
+    // many enter events we've gotten for the target, minus the number of leave
+    // events. This is the most reliable way to tell whether the cursor is still
+    // over the target.
+    counter: number;
+  }> = [];
+
+  private readonly subscribers = new Set<SubscriberCallback>();
+
+  getDragged(): Target | undefined {
+    return this.dragged;
+  }
+
+  getHovered(): Target | undefined {
+    return this.hovered[this.hovered.length - 1]?.target;
+  }
+
+  /**
+   * Handles the start of a drag event.
+   *
+   * Any element that wants to support the start of a drag should call this
+   * function in its @dragstart event handler.
+   *
+   * @param event: Required except in tests. The drag event.
+   */
+  onDragStart(event: DragEvent | undefined, target: Target) {
+    event?.stopPropagation();
+    if (event) {
+      // On Mac, dragging results in a green plus icon being shown besides the
+      // cursor. It is a bit annoying, and can be disabled by setting
+      // `event.dataTransfer.effectAllowed`.
+      // However, setting that causes cursors on Linux to flicker. It constantly
+      // switches between the grab cursor and the forbidden cursor.
+      if (isMac()) {
+        disableGreenPlusIcon(event);
+      }
+    }
+    this.dragged = target;
+    this.informSubscribers();
+  }
+
+  /**
+   * Handles the end of a drag event.
+   *
+   * Any element that calls onDragStart on @dragstart should also call this
+   * function in its @dragend event handler.
+   */
+  onDragEnd(event: DragEvent): {source: Target; dest: Target} | undefined {
+    event.stopPropagation();
+    let response;
+    const source = this.dragged;
+    const dest = this.getHovered();
+    if (source !== undefined && dest !== undefined) {
+      response = {source, dest};
+    }
+    this.dragged = undefined;
+    this.hovered.length = 0;
+    this.informSubscribers();
+    return response;
+  }
+
+  /**
+   * Handles the enter event of a drag event.
+   *
+   * Any element that wants to make hovering over it change how the graph is
+   * rendered should call this function in its @dragenter event handler.
+   */
+  onDragEnter(event: DragEvent, target: Target) {
+    if (this.dragged === undefined || isEqual(target, this.dragged)) {
+      return;
+    }
+    // Don't show multi-selected commits as a drop target.
+    if (isMultiSelected(this.dragged) && isMultiSelected(target)) {
+      return;
+    }
+
+    const hovered = this.hovered[this.hovered.length - 1];
+    if (hovered !== undefined && isEqual(target, hovered.target)) {
+      hovered.counter += 1;
+      return;
+    }
+
+    this.hovered.push({
+      target,
+      counter: 1,
+    });
+    this.informSubscribers();
+  }
+
+  onDragOver(event: DragEvent) {
+    // Needed to avoid lag when dragging.
+    event.preventDefault();
+  }
+
+  onDragLeave(event: DragEvent, target: Target) {
+    for (let i = 0; i < this.hovered.length; i++) {
+      const hovered = this.hovered[i];
+      if (isEqual(hovered.target, target)) {
+        hovered.counter -= 1;
+        if (hovered.counter === 0) {
+          this.hovered.splice(i, 1);
+          this.informSubscribers();
+        }
+        return;
+      }
+    }
+  }
+
+  private informSubscribers() {
+    for (const cb of this.subscribers) {
+      cb();
+    }
+  }
+
+  subscribe(callback: SubscriberCallback) {
+    if (this.subscribers.has(callback)) {
+      throw new Error('Callback is already subscribed.');
+    }
+    this.subscribers.add(callback);
+  }
+
+  unsubscribe(callback: SubscriberCallback) {
+    if (!this.subscribers.delete(callback)) {
+      throw new Error('Callback was not subscribed.');
+    }
+  }
+}
+
+const globalDragAndDropStateManager = new DragAndDropStateManager();
+
+/**
+ * Returns the global drag and drop manager.
+ */
+export function getManager() {
+  return globalDragAndDropStateManager;
+}
+
+function disableGreenPlusIcon(event: DragEvent) {
+  if (!event.dataTransfer) {
+    throw new Error('No dataTransfer in DragEvent');
+  }
+  // Hides the green plus icon shown when hovered over some elements.
+  event.dataTransfer.effectAllowed = 'move';
+}
+
+function isMultiSelected(target: Target) {
+  return target.type === 'commit' && target.data.isMultiSelected;
+}

--- a/src/ui/commit_graph/components/drag_and_drop_state_test.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_state_test.ts
@@ -1,0 +1,345 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jasmine';
+import {CommitNode} from '../api/types';
+import {
+  DragAndDropStateManager,
+  createCommitTarget,
+  isNoopInsert,
+} from './drag_and_drop_state';
+
+/** Creates a fake CommitNode for testing. */
+function newCommitNode(node: Partial<CommitNode>): CommitNode {
+  return {
+    hash: '',
+    childrenHashes: [],
+    shortDescription: '',
+    fullDescription: '',
+    isEmpty: false,
+    bookmarkChips: [],
+    displayId: '',
+    highlightedDisplayIdLen: 0,
+    updateTime: 0,
+    isMultiSelected: false,
+    children: [],
+    parents: [],
+    isMagicRoot: false,
+    disjointSetId: 0,
+    descendants: new Set<string>(),
+    traverseOrder: 0,
+    smallestTraverseOrder: 0,
+    x: 0,
+    y: 0,
+    tileGroups: [],
+    occupiedColumns: 0,
+    ...node,
+  };
+}
+
+describe('DragAndDropState', () => {
+  const fakeEvent = jasmine.createSpyObj<DragEvent>('DragEvent', [
+    'stopPropagation',
+    'preventDefault',
+  ]);
+
+  it('Drag the source node, and hover over it', () => {
+    const manager = new DragAndDropStateManager();
+    let count = 0;
+    const cb = () => {
+      ++count;
+    };
+
+    const draggedNode = createCommitTarget(newCommitNode({hash: 'source'}));
+
+    // onDragStart on the source node.
+    manager.subscribe(cb);
+    expect(count).toEqual(0);
+    manager.onDragStart(undefined, draggedNode);
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+
+    // onDragEnter on the dragged node is a no-op, and should not increase the
+    // count.
+    manager.onDragEnter(fakeEvent, draggedNode);
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+
+    // onDragLeave on the dragged node is a no-op, and should not increase the
+    // count.
+    manager.onDragLeave(fakeEvent, draggedNode);
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+  });
+
+  it('Drag a multi-selected source node, and hover over another multi-selected node', () => {
+    const manager = new DragAndDropStateManager();
+    let count = 0;
+    const cb = () => {
+      ++count;
+    };
+
+    const draggedNode = createCommitTarget(
+      // The dragged node should be multi-selected.
+      newCommitNode({hash: 'source', isMultiSelected: true}),
+    );
+    manager.subscribe(cb);
+    manager.onDragStart(undefined, draggedNode);
+    expect(count).toEqual(1);
+
+    // onDragEnter on multi-selected node is also a no-op.
+    manager.onDragEnter(
+      fakeEvent,
+      createCommitTarget(
+        newCommitNode({hash: 'multi-selected', isMultiSelected: true}),
+      ),
+    );
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+  });
+
+  it('Drag over the source node, and hover over another node', () => {
+    const manager = new DragAndDropStateManager();
+    let count = 0;
+    const cb = () => {
+      ++count;
+    };
+
+    const draggedNode = createCommitTarget(newCommitNode({hash: 'source'}));
+    const hoveredNode = createCommitTarget(newCommitNode({hash: 'hovered'}));
+
+    // onDragStart on the source node.
+    manager.subscribe(cb);
+    expect(count).toEqual(0);
+    manager.onDragStart(undefined, draggedNode);
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+
+    // onDragEnter on another node.
+    manager.onDragEnter(fakeEvent, hoveredNode);
+    expect(count).toEqual(2);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toEqual(hoveredNode);
+
+    // A second onDragEnter on the same node should not break things.
+    // Note: This can happen in practice. HTML Drag and drop events can fire
+    // multiple enter events for the same node. e.g. We could get enter, enter,
+    // leave.
+    manager.onDragEnter(fakeEvent, hoveredNode);
+    expect(count).toEqual(2);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toEqual(hoveredNode);
+
+    // Element should still be considered hovered after the first onDragLeave event.
+    manager.onDragLeave(fakeEvent, hoveredNode);
+    expect(count).toEqual(2);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toEqual(hoveredNode);
+
+    // Second onDragLeave should clear the hovered node.
+    manager.onDragLeave(fakeEvent, hoveredNode);
+    expect(count).toEqual(3);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+  });
+
+  it('Drag the source node, and drop it', () => {
+    const manager = new DragAndDropStateManager();
+    let count = 0;
+    const cb = () => {
+      ++count;
+    };
+
+    const draggedNode = createCommitTarget(newCommitNode({hash: 'source'}));
+    const hoveredNode = createCommitTarget(newCommitNode({hash: 'hovered'}));
+
+    // onDragStart on the source node.
+    manager.subscribe(cb);
+    expect(count).toEqual(0);
+    manager.onDragStart(undefined, draggedNode);
+    expect(count).toEqual(1);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toBeUndefined();
+
+    // onDragEnter on another node.
+    manager.onDragEnter(fakeEvent, hoveredNode);
+    expect(count).toEqual(2);
+    expect(manager.getDragged()).toEqual(draggedNode);
+    expect(manager.getHovered()).toEqual(hoveredNode);
+
+    // onDragEnd should clear both the dragged and hovered nodes.
+    expect(manager.onDragEnd(fakeEvent)).toEqual({
+      source: draggedNode,
+      dest: hoveredNode,
+    });
+    expect(count).toEqual(3);
+    expect(manager.getDragged()).toBeUndefined();
+    expect(manager.getHovered()).toBeUndefined();
+  });
+
+  it('subscribes and unsubscribes correctly', () => {
+    const manager = new DragAndDropStateManager();
+    const cb = () => {};
+    manager.subscribe(cb);
+    manager.unsubscribe(cb);
+    expect(() => {
+      manager.unsubscribe(cb);
+    }).toThrowError('Callback was not subscribed.');
+  });
+
+  it('throws error when subscribing twice', () => {
+    const manager = new DragAndDropStateManager();
+    const cb = () => {};
+    manager.subscribe(cb);
+    expect(() => {
+      manager.subscribe(cb);
+    }).toThrowError('Callback is already subscribed.');
+  });
+
+  it('throws error when unsubscribing something that was not subscribed', () => {
+    const manager = new DragAndDropStateManager();
+    const cb = () => {};
+    expect(() => {
+      manager.unsubscribe(cb);
+    }).toThrowError('Callback was not subscribed.');
+  });
+});
+
+describe('isNoopInsert', () => {
+  it('returns true if from is undefined and dragged is to', () => {
+    const node = newCommitNode({hash: 'node'});
+    const dragged = {type: 'commit', data: node} as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: undefined,
+        to: node,
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns true if to is undefined and dragged is from', () => {
+    const node = newCommitNode({hash: 'node'});
+    const dragged = {type: 'commit', data: node} as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: node,
+        to: undefined,
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns true if to is immutable', () => {
+    const dragged = {
+      type: 'commit',
+      data: newCommitNode({hash: 'dragged'}),
+    } as const;
+    const to = newCommitNode({hash: 'to', isImmutable: true});
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: undefined,
+        to,
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns true if to is undefined and from has an immutable child', () => {
+    const immutableChild = newCommitNode({
+      hash: 'immutable',
+      isImmutable: true,
+    });
+    const dragged = {
+      type: 'commit',
+      data: newCommitNode({hash: 'dragged'}),
+    } as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: newCommitNode({
+          hash: 'from',
+          children: [{node: immutableChild, lineX: 0}],
+        }),
+        to: undefined,
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns true if from is dragged', () => {
+    const node = newCommitNode({hash: 'node'});
+    const dragged = {type: 'commit', data: node} as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: node,
+        to: newCommitNode({hash: 'to'}),
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns true if to is dragged', () => {
+    const node = newCommitNode({hash: 'node'});
+    const dragged = {type: 'commit', data: node} as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: newCommitNode({hash: 'from'}),
+        to: node,
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeTrue();
+  });
+
+  it('returns false for a valid insert', () => {
+    const dragged = {
+      type: 'commit',
+      data: newCommitNode({hash: 'dragged'}),
+    } as const;
+    const hovered = {
+      type: 'insert',
+      data: {
+        from: newCommitNode({hash: 'from'}),
+        to: newCommitNode({hash: 'to'}),
+        insertNode: {x: 0, y: 0},
+        insertHint: {x: 0, y: 0},
+      },
+    } as const;
+    expect(isNoopInsert(dragged, hovered)).toBeFalse();
+  });
+});

--- a/src/ui/commit_graph/components/drag_and_drop_subscriber.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_subscriber.ts
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement} from 'lit';
+import {customElement, property, state} from 'lit/decorators';
+import type {Target} from './drag_and_drop_state';
+import {getManager, isEqual} from './drag_and_drop_state';
+
+/**
+ * A LitElement that subscribes to drag and drop events.
+ *
+ * This LitElement subscribes to drag and drop events published by
+ * <jj-drag-and-drop-publisher>. See drag_and_drop_publisher.ts for more
+ * details.
+ *
+ * Users of this component should extend this class, and use `isDragSource` and
+ * `isDragDestination` to determine whether the element is the source or
+ * destination of the drag.
+ */
+@customElement('jj-drag-and-drop-subscriber')
+export class JjDragAndDropSubscriber extends LitElement {
+  // If defined, this LitElement will subscribe to drag and drop events of
+  // the provided target. If undefined, this LitElement does not subscribe to
+  // any drag and drop events.
+  @property({attribute: false}) subscribedTarget?: Target;
+
+  @state() isDragSource = false;
+  @state() isDragDestination = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    getManager().subscribe(this.stateChanged);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    getManager().unsubscribe(this.stateChanged);
+  }
+
+  private readonly stateChanged = () => {
+    if (this.subscribedTarget === undefined) {
+      return;
+    }
+    const dragged = getManager().getDragged();
+    let hovered = getManager().getHovered();
+
+    // When dragging a commit or a bookmark onto a bookmark, we still want to show it's
+    // the commit that is being hovered over.
+    if (
+      (dragged?.type === 'commit' || dragged?.type === 'bookmark') &&
+      hovered?.type === 'bookmark'
+    ) {
+      hovered = {
+        type: 'commit',
+        data: hovered.data.node,
+      };
+    }
+
+    this.isDragSource = isEqual(this.subscribedTarget, dragged);
+    this.isDragDestination = isEqual(this.subscribedTarget, hovered);
+  };
+}
+
+/**
+ * A LitElement that subscribes to drag and drop events of all targets.
+ */
+export class JjDragAndDropAllTargetsSubscriber extends LitElement {
+  @state() dragged?: Target;
+  @state() hovered?: Target;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    getManager().subscribe(this.stateChanged);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    getManager().unsubscribe(this.stateChanged);
+  }
+
+  private readonly stateChanged = () => {
+    this.dragged = getManager().getDragged();
+    this.hovered = getManager().getHovered();
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-drag-and-drop-subscriber': JjDragAndDropSubscriber;
+  }
+}

--- a/src/ui/commit_graph/components/focus_mode_text.ts
+++ b/src/ui/commit_graph/components/focus_mode_text.ts
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState} from '../api/types';
+
+@customElement('jj-focus-mode-text')
+class JjFocusModeText extends LitElement {
+  static override styles = css`
+    .wrapper {
+      margin-left: 5px;
+      font-style: italic;
+      margin-top: 5px;
+    }
+    .link {
+      color: var(--vscode-textLink-foreground);
+      cursor: pointer;
+    }
+    .link:hover {
+      text-decoration: underline;
+    }
+  `;
+
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+
+  override render() {
+    const disableFocusMode = this.state.options.disableFocusMode;
+    if (!disableFocusMode || !this.state.unfocusedCommits) {
+      return html``;
+    }
+    return html`<div class="wrapper">
+      <span
+        class="link"
+        @click=${() =>
+          this.extensionApi.$executeCommand(
+            this.state.repoName,
+            disableFocusMode.command,
+            disableFocusMode.arguments,
+          )}
+        >Disable focus mode</span
+      >
+      to see the other ${this.state.unfocusedCommits} commits in this workspace.
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-focus-mode-text': JjFocusModeText;
+  }
+}

--- a/src/ui/commit_graph/components/garbage_section.ts
+++ b/src/ui/commit_graph/components/garbage_section.ts
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState} from '../api/types';
+import {TOP_BAR_HEIGHT} from './constants';
+import {GARBAGE_SECTION_TARGET} from './drag_and_drop_state';
+import {JjDragAndDropSubscriber} from './drag_and_drop_subscriber';
+
+import './codicon';
+
+@customElement('jj-garbage-section')
+class JjGarbageSection extends JjDragAndDropSubscriber {
+  static override get styles() {
+    return css`
+      :host {
+        display: flex;
+        /** -1 to create a small gap between the top bar and the commit graph. */
+        height: ${TOP_BAR_HEIGHT - 1}px;
+        margin: auto 5px;
+      }
+      .jj-drag-and-drop-publisher {
+        width: 100%;
+        border-width: 2px;
+        border-style: dashed;
+        border-radius: 4px;
+        color: var(--jj-garbageSection-color);
+        background-color: var(--jj-garbageSection-backgroundColor);
+        border-color: var(--jj-garbageSection-borderColor);
+      }
+      .jj-drag-and-drop-publisher[isHovered] {
+        color: var(--jj-garbageSection-hoverColor);
+        background-color: var(--jj-garbageSection-hoverBackgroundColor);
+        border-color: var(--jj-garbageSection-hoverBorderColor);
+      }
+      .container {
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+      /**
+       * Disable pointer events for children of the container to prevent them
+       * from triggering drag and drop events.
+       */
+      .container > * {
+        pointer-events: none;
+      }
+    `;
+  }
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  override render() {
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${GARBAGE_SECTION_TARGET}
+        .extensionApi=${this.extensionApi}
+        .state=${this.state}
+        class="jj-drag-and-drop-publisher"
+        ?isHovered=${this.isDragDestination}
+      >
+        <div class="container">
+          <jj-codicon
+            .codicon=${'codicon-trash'}
+            .color=${this.isDragDestination
+              ? 'var(--jj-garbageSection-hoverColor)'
+              : 'var(--jj-garbageSection-color)'}
+          ></jj-codicon>
+          ${this.getHintText()}
+        </div>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+
+  private getHintText() {
+    const multiSelectedCount = this.state.commits.filter(
+      (commit) => commit.isMultiSelected,
+    ).length;
+    if (multiSelectedCount > 1) {
+      if (this.isDragDestination) {
+        return `Abandon ${multiSelectedCount} commits`;
+      } else {
+        return `Drop here to abandon ${multiSelectedCount} commits`;
+      }
+    } else {
+      if (this.isDragDestination) {
+        return 'Abandon';
+      } else {
+        return 'Drop here to abandon';
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-garbage-section': JjGarbageSection;
+  }
+}

--- a/src/ui/commit_graph/components/glyph_tile.ts
+++ b/src/ui/commit_graph/components/glyph_tile.ts
@@ -1,0 +1,216 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, svg} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {styleMap} from 'lit/directives/style-map';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode, Tile} from '../api/types';
+import {COMMIT_ROW_HEIGHT, TILE_HEIGHT, TILE_WIDTH} from './constants';
+import {isDraggable} from './drag_and_drop_publisher';
+import {
+  createCommitTarget,
+  createInsertTarget,
+  isNoopInsert,
+} from './drag_and_drop_state';
+import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
+import {svgAtSymbol, svgCircle, svgCross, svgDiamond} from './glyphs';
+import {getSvgLine} from './lines';
+
+import './drag_and_drop_publisher';
+import './insert_hint';
+import './insert_node';
+import './rebase_hint';
+
+@customElement('jj-glyph-tile')
+class JjGlyphTile extends JjDragAndDropAllTargetsSubscriber {
+  static override styles = css`
+    :host {
+      display: flex;
+      width: ${TILE_WIDTH}px;
+      height: ${TILE_HEIGHT}px;
+      position: relative;
+    }
+    .svg-container {
+      width: 100%;
+      height: 100%;
+    }
+    svg {
+      position: absolute;
+      overflow: visible;
+      width: 100%;
+      height: 100%;
+    }
+  `;
+
+  // If set, the tile should draw the commit.
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) glyphTile!: Tile;
+  @property({attribute: false}) shouldDrawGlyph!: boolean;
+  @property({attribute: false}) x!: number;
+
+  override render() {
+    const styles = styleMap({
+      cursor: this.shouldDrawGlyph ? 'pointer' : undefined,
+    });
+    const target = this.shouldDrawGlyph
+      ? createCommitTarget(this.node)
+      : createInsertTarget(this.glyphTile.insertAction);
+
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${target}
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        style=${styles}
+      >
+        <div
+          draggable="${target !== undefined && isDraggable(target, this.state)}"
+          class="svg-container"
+        >
+          ${this.renderLines()} ${this.renderGlyph()} ${this.renderRebaseHint()}
+          ${this.renderInsertHintAndNode()}
+        </div>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+
+  private renderLines() {
+    return this.glyphTile.lines.map((line) =>
+      getSvgLine(line, this.dragged, this.hovered, {
+        tileWidth: TILE_WIDTH,
+        tileHeight: TILE_HEIGHT,
+      }),
+    );
+  }
+
+  private renderGlyph() {
+    if (!this.shouldDrawGlyph) {
+      return svg``;
+    }
+    const color = this.getGlyphColor();
+    const glyphs = [];
+    if (this.node.active) {
+      glyphs.push(svgAtSymbol(color));
+    } else if (this.node.isImmutable) {
+      glyphs.push(svgDiamond(color));
+    } else if (this.node.hasConflict) {
+      glyphs.push(svgCross(color));
+    } else {
+      glyphs.push(svgCircle(color));
+    }
+    return svg`<svg><g>${glyphs}</g></svg>`;
+  }
+
+  private getGlyphColor() {
+    const isDragged =
+      this.dragged?.type === 'commit' && this.dragged.data === this.node;
+    if (isDragged || this.isDragDestination()) {
+      return 'var(--vscode-button-background)';
+    }
+    if (this.node.hasConflict) {
+      return 'var(--vscode-editorError-foreground)';
+    }
+    if (
+      this.dragged?.type !== 'commit' &&
+      this.node.isWorkingCopyCommitAncestor
+    ) {
+      return 'var(--vscode-foreground)';
+    }
+    return 'var(--inactiveLineColor)';
+  }
+
+  private renderRebaseHint() {
+    if (this.isDragDestination()) {
+      return html`<jj-rebase-hint> </jj-rebase-hint>`;
+    }
+    return html``;
+  }
+
+  private isDragDestination() {
+    return (
+      this.shouldDrawGlyph &&
+      this.dragged?.type === 'commit' &&
+      this.dragged.data !== this.node &&
+      ((this.hovered?.type === 'commit' && this.hovered.data === this.node) ||
+        (this.hovered?.type === 'bookmark' &&
+          this.hovered.data.node === this.node))
+    );
+  }
+
+  private renderInsertHintAndNode() {
+    let hintText: string | undefined;
+    if (this.dragged?.type === 'commit' && this.hovered?.type === 'insert') {
+      const {from, to, insertNode, insertHint} = this.hovered.data;
+      if (isNoopInsert(this.dragged, this.hovered)) {
+        return html``;
+      }
+      if (this.shouldDrawGlyph && from === this.node && to === undefined) {
+        hintText = 'Insert as common parent';
+      } else if (
+        this.shouldDrawGlyph &&
+        from === undefined &&
+        to === this.node
+      ) {
+        hintText = 'Insert as common child';
+      } else if (
+        from !== undefined &&
+        to !== undefined &&
+        Math.floor(insertNode.x) === this.x &&
+        Math.floor(insertNode.y) === this.node.y
+      ) {
+        hintText = 'Insert between';
+      }
+
+      if (hintText) {
+        return html`${this.renderInsertHint(hintText, insertHint)}
+        ${this.renderInsertNode(insertNode)} `;
+      }
+    }
+    return html``;
+  }
+
+  private renderInsertHint(
+    hintText: string,
+    insertHint: {x: number; y: number},
+  ) {
+    const skewX = (insertHint.x - this.x) * TILE_WIDTH;
+    const skewY = (insertHint.y - this.node.y) * COMMIT_ROW_HEIGHT;
+    return html`<jj-insert-hint
+      .text="${hintText}"
+      .skewX=${skewX}
+      .skewY=${skewY}
+    >
+    </jj-insert-hint>`;
+  }
+
+  private renderInsertNode(insertNode: {x: number; y: number}) {
+    const skewX = (insertNode.x - this.x) * TILE_WIDTH;
+    const skewY = (insertNode.y - this.node.y) * COMMIT_ROW_HEIGHT;
+    return html`<jj-insert-node
+      .skewX=${skewX}
+      .skewY=${skewY}
+    ></jj-insert-node>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-glyph-tile': JjGlyphTile;
+  }
+}

--- a/src/ui/commit_graph/components/glyphs.ts
+++ b/src/ui/commit_graph/components/glyphs.ts
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {svg} from 'lit';
+import {
+  CIRCLE_RADIUS,
+  STROKE_WIDTH,
+  TILE_HEIGHT,
+  TILE_WIDTH,
+} from './constants';
+
+/**
+ * A circle icon, typically used for unsubmitted commits.
+ */
+export function svgCircle(
+  color: string,
+  dimensions?: {
+    r: number;
+  },
+) {
+  const r = dimensions?.r ?? CIRCLE_RADIUS;
+  return svg`
+    <circle
+      cx="${TILE_WIDTH / 2}"
+      cy="${TILE_HEIGHT / 2}"
+      r="${r}"
+      fill="${color}"
+    ></circle>
+  `;
+}
+
+// The idea of sqrt is to make the diamond icon have the same area as circles.
+const DIAMOND_SIDE = CIRCLE_RADIUS * Math.sqrt(3.14);
+
+/**
+ * A diamond icon, typically used for submitted commits.
+ */
+export function svgDiamond(color: string) {
+  return svg`
+    <g transform="translate(${TILE_WIDTH / 2}, ${TILE_HEIGHT / 2})">
+      <rect
+        x="${-DIAMOND_SIDE / 2}"
+        y="${-DIAMOND_SIDE / 2}"
+        width="${DIAMOND_SIDE}"
+        height="${DIAMOND_SIDE}"
+        fill="none"
+        stroke="${color}"
+        stroke-width="${STROKE_WIDTH}"
+        transform="rotate(45)"
+      ></rect>
+    </g>
+  `;
+}
+
+const CROSS_WIDTH = Math.min(TILE_WIDTH, TILE_HEIGHT) * 0.5;
+const HALF_CROSS_WIDTH = CROSS_WIDTH / 2;
+
+/**
+ * A cross icon, typically used for conflicted commits.
+ */
+export function svgCross(color: string) {
+  return svg`
+    <g transform="translate(${TILE_WIDTH / 2}, ${TILE_HEIGHT / 2})" stroke="${color}" stroke-width="${STROKE_WIDTH}">
+      <line x1="${-HALF_CROSS_WIDTH}" y1="${-HALF_CROSS_WIDTH}" x2="${HALF_CROSS_WIDTH}" y2="${HALF_CROSS_WIDTH}" />
+      <line x1="${-HALF_CROSS_WIDTH}" y1="${HALF_CROSS_WIDTH}" x2="${HALF_CROSS_WIDTH}" y2="${-HALF_CROSS_WIDTH}" />
+    </g>
+  `;
+}
+
+/**
+ * An @ symbol, typically used for the working copy commit.
+ */
+export function svgAtSymbol(color: string) {
+  return svg`
+    <text
+      x = "${TILE_WIDTH / 2}"
+      y = "${TILE_HEIGHT / 2}"
+      style="
+        font: 16px sans-serif;
+        text-anchor: middle;
+        dominant-baseline: middle;
+        alignment-baseline: central;
+        fill: ${color}
+      "
+    > @ </text>
+  `;
+}

--- a/src/ui/commit_graph/components/hint_bubble.ts
+++ b/src/ui/commit_graph/components/hint_bubble.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css} from 'lit';
+
+/**
+ * Styles for all hint bubbles.
+ */
+export const HINT_BUBBLE_STYLES = css`
+  :host {
+    pointer-events: none;
+  }
+  svg {
+    position: absolute;
+    z-index: 10;
+    top: 0;
+    left: 0;
+    overflow: visible;
+    filter: drop-shadow(0px 1px 1px rgba(0, 0, 0, 1));
+    /**
+     * We must define a max width and height for this element. Otherwise
+     * when dragging and dropping, the svg can glitch. It glitches because
+     *  - when dragging and scrolling to the very bottom of the graph
+     *  - rebase hint appears for the bottommost commit
+     *  - the svg's large height causes the graph to grow in height
+     *  - this causes the mouse position to leave the commit row
+     *  - which causes the rebase hint to disappear
+     *  - which causes the graph shrink back
+     *  - repeat back to the first point.
+     *
+     * To avoid this, we set a max width and height. It doesn't matter
+     * what the width and height are as long as they are small enough.
+     */
+    max-width: 10px;
+    max-height: 10px;
+  }
+  path {
+    stroke: var(--vscode-button-background);
+    fill: transparent;
+    stroke-width: 2px;
+  }
+  rect {
+    fill: var(--vscode-button-background);
+  }
+  text {
+    text-anchor: middle;
+    dominant-baseline: middle;
+    fill: var(--vscode-button-foreground);
+  }
+`;

--- a/src/ui/commit_graph/components/insert_hint.ts
+++ b/src/ui/commit_graph/components/insert_hint.ts
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {TILE_HEIGHT, TILE_WIDTH} from './constants';
+import {HINT_BUBBLE_STYLES} from './hint_bubble';
+
+const HINT_BUBBLE_HEIGHT = 20;
+
+@customElement('jj-insert-hint')
+class JjInsertHint extends LitElement {
+  static override styles = HINT_BUBBLE_STYLES;
+
+  @property({attribute: false}) text!: string;
+  @property({attribute: false}) skewX = 0;
+  @property({attribute: false}) skewY = 0;
+
+  override render() {
+    const width = 8 * this.text.length;
+    return html`
+      <svg>
+        <g transform="translate(${this.skewX + 4}, ${-this.skewY})">
+          <rect
+            x="${TILE_WIDTH}"
+            y="${TILE_HEIGHT / 2 - HINT_BUBBLE_HEIGHT / 2}"
+            width="${width}"
+            height="${HINT_BUBBLE_HEIGHT}"
+            rx="5"
+          ></rect>
+          <text x="${TILE_WIDTH + width / 2}" y="${TILE_HEIGHT / 2}">
+            ${this.text}
+          </text>
+        </g>
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-insert-hint': JjInsertHint;
+  }
+}

--- a/src/ui/commit_graph/components/insert_node.ts
+++ b/src/ui/commit_graph/components/insert_node.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import {svgCircle} from './glyphs';
+
+@customElement('jj-insert-node')
+class JjInsertNode extends LitElement {
+  static override get styles() {
+    return css`
+      :host {
+        pointer-events: none;
+      }
+      svg {
+        position: absolute;
+        z-index: 1;
+        top: 0;
+        left: 0;
+        overflow: visible;
+        max-width: 10px;
+        max-height: 10px;
+      }
+    `;
+  }
+
+  @property({attribute: false}) skewX!: number;
+  @property({attribute: false}) skewY!: number;
+
+  override render() {
+    return html`
+      <svg>
+        <g transform="translate(${this.skewX}, ${-this.skewY})">
+          ${svgCircle('var(--vscode-button-background)', {
+            r: 5,
+          })}
+        </g>
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-insert-node': JjInsertNode;
+  }
+}

--- a/src/ui/commit_graph/components/lines.ts
+++ b/src/ui/commit_graph/components/lines.ts
@@ -1,0 +1,207 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {checkExhaustive} from '../utils/check';
+import {svg} from 'lit';
+import {InsertAction, Line, LineType} from '../api/types';
+import {STROKE_WIDTH} from './constants';
+import {isNoopInsert, Target} from './drag_and_drop_state';
+
+/**
+ * When rendering the commit graph in VSCode, there is an unknown tiny gap
+ * (< 0.5 px) in between the tiles. To avoid this, we add a small offset to
+ * extend the lines and cover the gap.
+ *
+ * Note that this problem only happens in VSCode. When the graph is rendered
+ * in the browser, there is no gap.
+ */
+const VSCODE_OFFSET = 0.5;
+
+interface SvgDimensions {
+  tileWidth: number;
+  tileHeight: number;
+  color?: string;
+}
+
+/**
+ * Returns the color and priority of a line.
+ */
+export function getLineColor(data: {
+  line: Line;
+  dragged: Target | undefined;
+  hovered: Target | undefined;
+}): {
+  // The color of the line.
+  color: string;
+  // The priority of the line. Lines with higher priority will be rendered on
+  // top of lines with lower priority.
+  priority: number;
+  // The width of the line.
+  strokeWidth: number;
+} {
+  const {line, dragged, hovered} = data;
+  let insert: InsertAction | undefined;
+  if (hovered?.type === 'insert') {
+    insert = hovered.data;
+  }
+  if (!isNoopInsert(dragged, hovered) && matches(line, insert)) {
+    return {
+      color: 'var(--vscode-button-background)',
+      priority: 2,
+      strokeWidth: 2.5,
+    };
+  }
+
+  if (
+    dragged?.type !== 'commit' &&
+    line.child.node.isWorkingCopyCommitAncestor
+  ) {
+    return {
+      color: 'var(--vscode-foreground)',
+      priority: 1,
+      strokeWidth: STROKE_WIDTH,
+    };
+  } else {
+    return {
+      color: 'var(--inactiveLineColor)',
+      priority: 0,
+      strokeWidth: STROKE_WIDTH,
+    };
+  }
+}
+
+function matches(line: Line, insert: InsertAction | undefined): boolean {
+  if (insert === undefined) {
+    return false;
+  }
+  if (insert.from === undefined) {
+    return line.child.node === insert.to;
+  }
+  if (insert.to === undefined) {
+    return line.parent === insert.from;
+  }
+  return line.child.node === insert.to && line.parent === insert.from;
+}
+
+/**
+ * Returns an SVG element for a given line.
+ */
+export function getSvgLine(
+  line: Line,
+  dragged: Target | undefined,
+  hovered: Target | undefined,
+  options: SvgDimensions,
+) {
+  const {color, priority, strokeWidth} = getLineColor({
+    line,
+    dragged,
+    hovered,
+  });
+  return svg`
+    <svg viewBox="0 0 ${options.tileWidth} ${options.tileHeight}" style="z-index: ${priority};">
+       <g
+      stroke="${color}"
+      fill="none"
+      stroke-width="${strokeWidth}"
+      style="pointer-events: none"
+    > ${getSvgLineInternal(line, options)} </g>
+    </svg>
+  `;
+}
+
+function getSvgLineInternal(line: Line, dimensions: SvgDimensions) {
+  switch (line.type) {
+    case LineType.VERTICAL:
+      return verticalLine(dimensions);
+    case LineType.HORIZONTAL:
+      return horizontalLine(dimensions);
+    case LineType.UP_TO_RIGHT:
+      return upToRight(dimensions);
+    case LineType.UP_TO_LEFT:
+      return upToLeft(dimensions);
+    case LineType.RIGHT_TO_UP:
+      return rightToUp(dimensions);
+    case LineType.LEFT_TO_UP:
+      return leftToUp(dimensions);
+    default:
+      checkExhaustive(line.type);
+  }
+}
+
+function verticalLine(dimensions: SvgDimensions) {
+  return svg`
+    <path d="
+      M ${dimensions.tileWidth / 2} -${VSCODE_OFFSET}
+      L ${dimensions.tileWidth / 2} ${dimensions.tileHeight + VSCODE_OFFSET}"
+    ></path>
+  `;
+}
+
+function horizontalLine(dimensions: SvgDimensions) {
+  return svg`
+    <path d="
+      M -${VSCODE_OFFSET} 0
+      L ${dimensions.tileWidth + VSCODE_OFFSET} 0"
+    ></path>
+  `;
+}
+
+/**
+ * See documentation for `LineType` for the shape of this line.
+ *
+ * This draws a Bezier curve. See
+ *  https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths#b%C3%A9zier_curves
+ *  https://svg-tutorial.com/editor/quadratic-bezier
+ */
+export function upToRight(dimensions: SvgDimensions) {
+  return svg`
+    <path d="
+      M ${dimensions.tileWidth / 2} ${dimensions.tileHeight}
+      Q ${dimensions.tileWidth / 2} 0 ${dimensions.tileWidth + VSCODE_OFFSET} 0"
+    ></path>
+  `;
+}
+
+function rightToUp(dimensions: SvgDimensions) {
+  return svg`
+    <g transform="translate(0, -${dimensions.tileHeight})">
+      <path d="
+        M -${VSCODE_OFFSET} ${dimensions.tileHeight}
+        Q ${dimensions.tileWidth / 2} ${dimensions.tileHeight} ${dimensions.tileWidth / 2} 0"
+      ></path>
+    </g>
+  `;
+}
+
+function upToLeft(dimensions: SvgDimensions) {
+  return svg`
+    <path d="
+      M ${-VSCODE_OFFSET} 0
+      Q ${dimensions.tileWidth / 2} 0 ${dimensions.tileWidth / 2} ${dimensions.tileHeight}"
+    ></path>
+  `;
+}
+
+function leftToUp(dimensions: SvgDimensions) {
+  return svg`
+    <g transform="translate(0, ${-dimensions.tileHeight})">
+      <path d="
+        M ${dimensions.tileWidth / 2} 0
+        Q ${dimensions.tileWidth / 2} ${dimensions.tileHeight} ${dimensions.tileWidth + VSCODE_OFFSET} ${dimensions.tileHeight}"
+      ></path>
+    </g>
+  `;
+}

--- a/src/ui/commit_graph/components/merge_tile.ts
+++ b/src/ui/commit_graph/components/merge_tile.ts
@@ -1,0 +1,96 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode, Tile} from '../api/types';
+import {MERGE_TILE_HEIGHT, TILE_WIDTH} from './constants';
+import {createInsertTarget} from './drag_and_drop_state';
+import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
+import {getSvgLine} from './lines';
+
+import './drag_and_drop_publisher';
+import './insert_hint';
+
+/**
+ * The type of the merge tile.
+ */
+export enum MergeTileType {
+  TOP,
+  BOTTOM,
+}
+
+@customElement('jj-merge-tile')
+class JjMergeTile extends JjDragAndDropAllTargetsSubscriber {
+  static override styles = css`
+    :host {
+      display: flex;
+      width: ${TILE_WIDTH}px;
+      height: ${MERGE_TILE_HEIGHT}px;
+      position: relative;
+    }
+    .svg-container {
+      display: flex;
+      align-items: flex-start;
+      width: 100%;
+      height: 100%;
+    }
+    svg {
+      position: absolute;
+      overflow: visible;
+      width: 100%;
+      height: 100%;
+    }
+  `;
+
+  @property({attribute: false}) tile!: Tile;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) shouldDrawGlyph!: boolean;
+  @property({attribute: false}) type!: MergeTileType;
+
+  override render() {
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${createInsertTarget(this.tile.insertAction)}
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        class="drag-and-drop-publisher"
+      >
+        <div draggable="${false}" class="svg-container">
+          ${this.renderLines()}
+        </div>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+
+  private renderLines() {
+    return this.tile.lines.map((line) =>
+      getSvgLine(line, this.dragged, this.hovered, {
+        tileWidth: TILE_WIDTH,
+        tileHeight: MERGE_TILE_HEIGHT,
+      }),
+    );
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-merge-tile': JjMergeTile;
+  }
+}

--- a/src/ui/commit_graph/components/rebase_hint.ts
+++ b/src/ui/commit_graph/components/rebase_hint.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, html} from 'lit';
+import {customElement} from 'lit/decorators';
+import {TILE_HEIGHT, TILE_WIDTH} from './constants';
+import {HINT_BUBBLE_STYLES} from './hint_bubble';
+import {upToRight} from './lines';
+
+const HINT_BUBBLE_WIDTH = 85;
+const HINT_BUBBLE_HEIGHT = 20;
+
+@customElement('jj-rebase-hint')
+class JjRebaseHint extends LitElement {
+  static override styles = HINT_BUBBLE_STYLES;
+
+  override render() {
+    return html`
+      <svg>
+        <g transform="translate(0, ${-TILE_HEIGHT / 2})">
+          ${upToRight({
+            tileWidth: TILE_WIDTH,
+            tileHeight: TILE_HEIGHT / 2,
+          })}
+        </g>
+        <g transform="translate(0 ${-TILE_HEIGHT})">
+          <rect
+            x="${TILE_WIDTH}"
+            y="${TILE_HEIGHT / 2 - HINT_BUBBLE_HEIGHT / 2}"
+            width="${HINT_BUBBLE_WIDTH}"
+            height="${HINT_BUBBLE_HEIGHT}"
+            rx="5"
+          ></rect>
+          <text
+            x="${TILE_WIDTH + HINT_BUBBLE_WIDTH / 2}"
+            y="${TILE_HEIGHT / 2}"
+          >
+            Rebase here
+          </text>
+        </g>
+      </svg>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-rebase-hint': JjRebaseHint;
+  }
+}

--- a/src/ui/commit_graph/components/resize_controller.ts
+++ b/src/ui/commit_graph/components/resize_controller.ts
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement} from 'lit';
+import {state} from 'lit/decorators';
+
+/**
+ * The direction of the resize event.
+ */
+enum Direction {
+  UNKNOWN,
+  INCREASING,
+  DECREASING,
+}
+
+/**
+ * Likely due to a VS Code bug or webview limitations, webviews gets resize
+ * events in an incorrect order. e.g. If you drag the webview and make it wider,
+ * typically we get resize events like the following:
+ * - width: x
+ * - width: x + 20
+ * - width: x + 30
+ * - width: x + 40
+ * - width: x
+ * - width: x + 22 // This doesn't have to be 20. It can be a new number.
+ * - width: x + 30
+ * - width: x + 40
+ *
+ * This is a known issue with VS Code webviews. For the commit graph, this
+ * causes the top bar blue buttons to "shake" because its sizes are not
+ * monotonically increasing/decreasing.
+ *
+ * A workaround is to use go/cider-native-view. It works perfectly, but it's
+ * a Cider specific feature and only works within google. This class provides
+ * another workaround. It alleviates the shaking issue by skipping resize events
+ * that are not in the intended direction. It does not work as well as native
+ * views, and is quite hacky, but it also works outside of google.
+ */
+export class JjResizeController extends LitElement {
+  /**
+   * The current width of the HTML element. As the `@state` annotation suggests,
+   * setting this field will trigger a re-render.
+   */
+  @state() protected renderedWidth?: number;
+
+  /**
+   * The widths that were rendered before. Since VS Code sends resize events
+   * in the incorrect order, skipping past widths help reduce a lot of noise.
+   *
+   * To ensure correctness, we create a `setTimeout` callback that will re-render
+   * the component after a short delay.
+   */
+  private readonly pastWidths = new Set<number>();
+
+  /**
+   *
+   * The id of the setTimeout callback that will re-render the component.
+   */
+  private renderAgain?: ReturnType<typeof setTimeout>;
+
+  /**
+   * The last width received from `resize` events.
+   */
+  private lastWidth?: number;
+
+  /**
+   * The last known direction of the resize event.
+   */
+  private direction = Direction.UNKNOWN;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('resize', this.handleResize);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  private readonly handleResize = () => {
+    if (!this.shadowRoot) {
+      return;
+    }
+    const incomingWidth = parseWidthString(
+      getComputedStyle(this.shadowRoot.host).getPropertyValue('width'),
+    );
+    if (incomingWidth === this.lastWidth) {
+      // This was fully processed before. No need to process again.
+      return;
+    }
+
+    const lastWidth = this.lastWidth;
+    this.lastWidth = incomingWidth;
+
+    // Create a setTimeout callback to ensure eventual consistency.
+    clearTimeout(this.renderAgain);
+    this.renderAgain = setTimeout(() => {
+      this.renderedWidth = incomingWidth;
+      this.pastWidths.clear();
+      this.direction = Direction.UNKNOWN;
+    }, 100);
+
+    if (this.pastWidths.has(incomingWidth)) {
+      return;
+    }
+    this.pastWidths.add(incomingWidth);
+
+    // Calculate the intended direction.
+    if (lastWidth === undefined) {
+      this.direction = Direction.UNKNOWN;
+    } else if (this.direction === Direction.UNKNOWN) {
+      this.direction = getDirection(lastWidth, incomingWidth);
+    } else {
+      const newDirection = getDirection(lastWidth, incomingWidth);
+      if (newDirection !== this.direction) {
+        this.direction = Direction.UNKNOWN;
+      }
+    }
+
+    // Only render if the intended direction matches the actual direction.
+    if (this.renderedWidth === undefined) {
+      this.renderedWidth = incomingWidth;
+    } else {
+      const actualDirection = getDirection(this.renderedWidth, incomingWidth);
+      if (actualDirection === this.direction) {
+        this.renderedWidth = incomingWidth;
+      }
+    }
+  };
+}
+
+function getDirection(before: number, after: number) {
+  return after > before ? Direction.INCREASING : Direction.DECREASING;
+}
+
+function parseWidthString(widthString: string): number {
+  if (widthString.endsWith('px')) {
+    return Number(widthString.slice(0, -2));
+  }
+  throw new Error(`Invalid width string: ${widthString}`);
+}

--- a/src/ui/commit_graph/components/safe_html.ts
+++ b/src/ui/commit_graph/components/safe_html.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {sanitizeHtml} from 'safevalues';
+import {unsafeHTML} from 'lit/directives/unsafe-html';
+
+export function safeHTML(unsafeHtml: string): ReturnType<typeof unsafeHTML> {
+  return unsafeHTML(sanitizeHtml(unsafeHtml).toString());
+}

--- a/src/ui/commit_graph/components/tile_group.ts
+++ b/src/ui/commit_graph/components/tile_group.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html, LitElement} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode, TileGroup} from '../api/types';
+import {MergeTileType} from './merge_tile';
+
+import './glyph_tile';
+import './merge_tile';
+
+@customElement('jj-tile-group')
+class JjTileGroup extends LitElement {
+  static override styles = css`
+    .tile-group {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      /** Position relative to allow the rebase hint to be absolute. */
+      position: relative;
+    }
+  `;
+
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) tileGroup!: TileGroup;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) x!: number;
+
+  override render() {
+    const shouldDrawGlyph = this.x === this.node.x;
+    return html` <div class="tile-group">
+      <jj-merge-tile
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        .tile=${this.tileGroup.top}
+        .node=${this.node}
+        .shouldDrawGlyph=${shouldDrawGlyph}
+        .type=${MergeTileType.TOP}
+      ></jj-merge-tile>
+      <jj-glyph-tile
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        .node=${this.node}
+        .glyphTile=${this.tileGroup.glyph}
+        .shouldDrawGlyph=${shouldDrawGlyph}
+        .x=${this.x}
+      >
+      </jj-glyph-tile>
+      <jj-merge-tile
+        .state=${this.state}
+        .extensionApi=${this.extensionApi}
+        .tile=${this.tileGroup.bottom}
+        .node=${this.node}
+        .shouldDrawGlyph=${shouldDrawGlyph}
+        .type=${MergeTileType.BOTTOM}
+      ></jj-merge-tile>
+    </div>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-tile-group': JjTileGroup;
+  }
+}

--- a/src/ui/commit_graph/components/time_ago_text.ts
+++ b/src/ui/commit_graph/components/time_ago_text.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {LitElement, css, html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+
+import {age} from '../utils/time';
+import type {CommitNode} from '../api/types';
+
+/** one minute in milliseconds */
+export const ONE_MINUTE_MS = 60 * 1e3;
+
+@customElement('jj-time-ago-text')
+class JjTimeAgoText extends LitElement {
+  static override styles = css`
+    :host {
+      user-select: none;
+    }
+  `;
+
+  @property({attribute: false}) text?: string;
+  @property({attribute: false}) node!: CommitNode;
+
+  // The id of the timeout event that triggers re-rendering the commit graph.
+  private renderAgain?: ReturnType<typeof setTimeout>;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    this.renderAgain = setInterval(async () => {
+      if (this.node === undefined) {
+        return;
+      }
+      this.requestUpdate();
+    }, ONE_MINUTE_MS);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    clearInterval(this.renderAgain);
+  }
+
+  override render() {
+    return html`${this.text ?? 'Submitted'} ${age(this.node.updateTime / 1000)}`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-time-ago-text': JjTimeAgoText;
+  }
+}

--- a/src/ui/commit_graph/components/top_bar.ts
+++ b/src/ui/commit_graph/components/top_bar.ts
@@ -1,0 +1,181 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {css, html} from 'lit';
+import {customElement, property, state} from 'lit/decorators';
+import {ifDefined} from 'lit/directives/if-defined';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState} from '../api/types';
+import {TOP_BAR_HEIGHT} from './constants';
+import {openContextMenu} from './context_menu_provider';
+import {GARBAGE_SECTION_TARGET} from './drag_and_drop_state';
+import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
+
+import './garbage_section';
+
+@customElement('jj-top-bar')
+class JjTopBar extends JjDragAndDropAllTargetsSubscriber {
+  static override styles = css`
+    :host {
+      display: block;
+      position: sticky;
+      z-index: 10;
+      top: 0px;
+      background-color: var(--vscode-sideBarStickyScroll-background);
+      height: ${TOP_BAR_HEIGHT}px;
+    }
+    .container {
+      background-color: var(--vscode-sideBar-background);
+    }
+    .container[scolled-down] {
+      box-shadow: 0 4px 2px -2px var(--vscode-sideBarStickyScroll-shadow);
+    }
+    .top-bar-left {
+      display: flex;
+      gap: 5px;
+      padding: 5px;
+    }
+    .codicon {
+      color: var(--vscode-button-secondaryForeground);
+      margin: 0;
+      font-size: 20px;
+    }
+
+    vscode-button[isOnlyElement],
+    vscode-button-group[isOnlyElement] {
+      width: calc(100% - 5px);
+    }
+  `;
+
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+
+  // If there are many commits in the graph, a user can scroll down to see more
+  // commits. When it's scrolled down, this variable should be set to true,
+  // so the top bar can show a bottom box shadow to give a visual cue that the
+  // top bar is sticky.
+  @state() private scrolledDown = false;
+
+  override connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener('scroll', this.scollEventListener);
+  }
+
+  override disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener('scroll', this.scollEventListener);
+  }
+
+  scollEventListener = () => {
+    this.scrolledDown = window.scrollY > 0;
+  };
+
+  override render() {
+    return html`
+      <div
+        class="container"
+        ?scolled-down=${this.scrolledDown}
+        @click=${() => {
+          void this.extensionApi.$clearMultiSelection(this.state.repoName);
+        }}
+      >
+        ${this.renderBody()}
+      </div>
+    `;
+  }
+
+  private renderBody() {
+    if (this.dragged) {
+      return this.renderGarbageSection();
+    }
+    return this.renderButtonGroup();
+  }
+
+  private renderButtonGroup() {
+    const isOnlyElement = this.state.topBarButtons.length === 1;
+    const buttons = this.state.topBarButtons.map(({left, right}) => {
+      if (right === undefined) {
+        return html` <vscode-button
+          ?isOnlyElement=${isOnlyElement}
+          ?disabled=${left.disabled}
+          title="${ifDefined(left.command.tooltip)}"
+          @click=${(event: MouseEvent) => {
+            event.stopPropagation();
+            void this.extensionApi.$executeCommand(
+              this.state.repoName,
+              left.command.command,
+              left.command.arguments,
+            );
+          }}
+          >${left.command.title}</vscode-button
+        >`;
+      }
+      const dataVscodeContext = `{
+        "origin": "${right.origin}",
+        "primaryCommand": "${left.command.command}",
+        "preventDefaultContextMenuItems": true
+      }`;
+      return html`
+        <vscode-button-group ?isOnlyElement=${isOnlyElement}>
+          <vscode-button
+            ?isOnlyElement=${isOnlyElement}
+            ?disabled=${left.disabled}
+            title="${ifDefined(left.command.tooltip)}"
+            @click=${(event: MouseEvent) => {
+              event.stopPropagation();
+              void this.extensionApi.$executeCommand(
+                this.state.repoName,
+                left.command.command,
+                left.command.arguments,
+              );
+            }}
+            >${left.command.title}</vscode-button
+          >
+          <vscode-button
+            ?disabled=${right.disabled ?? false}
+            icon="chevron-down"
+            @click=${(event: MouseEvent) => {
+              event.stopPropagation();
+              const target = (
+                event.target as HTMLElement
+              ).getBoundingClientRect();
+              openContextMenu({
+                dataVscodeContext,
+                clientX: target.left,
+                clientY: target.bottom,
+              });
+            }}
+          ></vscode-button>
+        </vscode-button-group>
+      `;
+    });
+    return html`<div class="top-bar-left">${buttons}</div>`;
+  }
+
+  private renderGarbageSection() {
+    return html`<jj-garbage-section
+      .subscribedTarget=${GARBAGE_SECTION_TARGET}
+      .extensionApi=${this.extensionApi}
+      .state=${this.state}
+    ></jj-garbage-section>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-top-bar': JjTopBar;
+  }
+}

--- a/src/ui/commit_graph/components/user_agent.ts
+++ b/src/ui/commit_graph/components/user_agent.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Returns whether the current operating system is a Mac.
+ */
+export function isMac(): boolean {
+  return navigator.userAgent.includes('Macintosh');
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,12 @@
     "stripInternal": true,
     "noImplicitOverride": true,
     "types": ["node"],
-    "experimentalDecorators": true
+    "experimentalDecorators": true,
+    "paths": {
+      "vscode-elements/main": ["./node_modules/@vscode-elements/elements"],
+      "lit/decorators": ["./node_modules/lit/decorators.d.ts", "./node_modules/lit/decorators.js"],
+      "lit/directives/*": ["./node_modules/lit/directives/*.d.ts", "./node_modules/lit/directives/*.js"]
+    }
   },
   "include": ["src", "third_party"],
   "ts-node": {


### PR DESCRIPTION
This PR tries to make only the minimal changes needed for code to compile. The majority of the code is copied with no (or trivial) changes, except for the following:

- BUILD.bazel: added an esbuild rule needed for vscode webviews
- MODULE.bazel: changes related to esbuild
- MODULE.bazel.lock: changes related to esbuild
- callout.ts and safe_html.ts: The lit directive Google internally uses (lit/directives/safe-html) isn't available externally, so I created a safe_html.ts that handles the sanitizing using google safevalues.
- tsconfig.json: Added a few rules

The commit graph is not completely working yet, expect more changes to gradually make everything work.
