### PR TITLE
Render a commit graph with fake data

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,16 @@
       }
     ],
     "menus": {},
-    "views": {}
+    "views": {
+      "scm": [
+        {
+          "id": "jj-dojo.commit-graph",
+          "name": "JJ Graph",
+          "type": "webview",
+          "visibility": "visible"
+        }
+      ]
+    }
   },
   "scripts": {
     "compile": "bazel build //:extension",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ export async function activate(context: vscode.ExtensionContext) {
   setGlobalLogger(logger);
   logInfo(`Extension version: ${context.extension.packageJSON.build}`);
 
-  const jjUi = new JjUi();
+  const jjUi = new JjUi(context);
   context.subscriptions.push(jjUi);
 
   logInfo('Extension activated successfully');

--- a/src/testing/custom_fakes/fake_window.ts
+++ b/src/testing/custom_fakes/fake_window.ts
@@ -35,6 +35,11 @@ export class FakeWindow {
       key: 'fake-decoration-type-key',
       dispose: () => {},
     });
+  readonly registerWebviewViewProvider = jasmine
+    .createSpy('registerWebviewViewProvider')
+    .and.returnValue({
+      dispose: () => {},
+    });
 
   createOutputChannel(name: string): FakeLogOutputChannel {
     const channel = this.outputChannels.get(name);

--- a/src/ui/commit_graph/components/app.ts
+++ b/src/ui/commit_graph/components/app.ts
@@ -19,7 +19,7 @@ import {createCommitNodes} from '../algorithms/preprocess';
 import {css, html} from 'lit';
 import {customElement, property} from 'lit/decorators';
 import {styleMap} from 'lit/directives/style-map';
-import 'vscode-elements/main'; // go/lit-style#importing-elements
+import 'vscode-elements/main';
 import type {ExtensionShape} from '../api/extension_shape';
 import type {CommitGraphState} from '../api/types';
 import {CommitNode} from '../api/types';

--- a/src/ui/commit_graph/webview_module.ts
+++ b/src/ui/commit_graph/webview_module.ts
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import './components/app';
+
+import {
+  Channel,
+  getExtensionApi,
+} from '../../../third_party/vscode/rpc_protocol/rpc_protocol';
+import type {ExtensionShape} from './api/extension_shape';
+import type {CommitGraphState} from './api/types';
+import {WebviewShape} from './api/webview_shape';
+import {JjApp} from './components/app';
+
+declare function acquireVsCodeApi(): {
+  postMessage(message: unknown): void;
+};
+
+function main() {
+  const vscode = acquireVsCodeApi();
+  const channel: Channel = {
+    postMessage: (message: unknown) => {
+      vscode.postMessage(message as {});
+    },
+    onMessage: (callback: (event: unknown) => void) => {
+      const listener = (event: MessageEvent) => {
+        callback(event.data);
+      };
+      window.addEventListener('message', listener);
+      return {
+        dispose: () => {
+          window.removeEventListener('message', listener);
+        },
+      };
+    },
+  };
+  // The disposable returned by getExtensionApi() is not cleaned up here.
+  // The allocated resources should be cleaned up when the webview is disposed.
+  getExtensionApi<ExtensionShape, WebviewShape>(channel, (extensionApi) => {
+    const jjApp = document.getElementById('jj-app') as JjApp;
+    jjApp.extensionApi = extensionApi;
+    void extensionApi.$webviewReady();
+    return {
+      async $setStates(states: CommitGraphState[]) {
+        await jjApp.setStates(states);
+      },
+    };
+  });
+}
+
+main();

--- a/src/ui/commit_graph_provider/commit_graph_provider.ts
+++ b/src/ui/commit_graph_provider/commit_graph_provider.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as vscode from 'vscode';
+import {
+  getWebviewApi,
+  Channel,
+  Disposable,
+} from '../../../third_party/vscode/rpc_protocol/rpc_protocol';
+import {ExtensionShape} from '../commit_graph/api/extension_shape';
+import {WebviewShape} from '../commit_graph/api/webview_shape';
+import {ExtensionShapeImpl} from './extension_shape_impl';
+import {dispose} from '../../utils/dispose';
+
+export class CommitGraphViewProvider implements vscode.WebviewViewProvider {
+  public static readonly viewType = 'jj-dojo.commit-graph';
+
+  constructor(private readonly extensionUri: vscode.Uri) {}
+
+  public async resolveWebviewView(
+    webviewView: vscode.WebviewView,
+    _context: vscode.WebviewViewResolveContext,
+    _token: vscode.CancellationToken,
+  ) {
+    webviewView.webview.options = {
+      // Allow scripts in the webview
+      enableScripts: true,
+      localResourceRoots: [this.extensionUri],
+    };
+    webviewView.webview.html = getHtmlForWebview(
+      this.extensionUri,
+      webviewView.webview,
+    );
+
+    const channel: Channel = {
+      postMessage: (msg: unknown) => {
+        void webviewView.webview.postMessage(msg);
+      },
+      onMessage: (cb: (event: unknown) => void): Disposable => {
+        const sub = webviewView.webview.onDidReceiveMessage(cb);
+        return {
+          dispose: () => sub.dispose(),
+        };
+      },
+    };
+    const disposables: vscode.Disposable[] = [];
+    const {disposable} = getWebviewApi<ExtensionShape, WebviewShape>(
+      channel,
+      (webviewApi) => {
+        return new ExtensionShapeImpl(webviewApi);
+      },
+    );
+    disposables.push(disposable);
+    disposables.push(
+      webviewView.onDidDispose(() => {
+        dispose(disposables);
+      }),
+    );
+  }
+}
+
+function getHtmlForWebview(
+  extensionUri: vscode.Uri,
+  webview: vscode.Webview,
+): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(
+      extensionUri,
+      'bazel-bin',
+      'out',
+      'src',
+      'ui',
+      'commit_graph',
+      'webview_module.bundle.js',
+    ),
+  );
+  const cssUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(
+      extensionUri,
+      'src',
+      'ui',
+      'commit_graph',
+      'components',
+      '_jj_graph_base_styles.css',
+    ),
+  );
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JJ Dojo Commit Graph</title>
+  <link rel="stylesheet" href="${cssUri}">
+  <script type="module" src="${scriptUri}"></script>
+</head>
+<body>
+  <jj-context-menu-provider></jj-context-menu-provider>
+  <jj-app id="jj-app"></jj-app>
+</body>
+</html>`;
+}

--- a/src/ui/commit_graph_provider/extension_shape_impl.ts
+++ b/src/ui/commit_graph_provider/extension_shape_impl.ts
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {ExtensionShape} from '../commit_graph/api/extension_shape';
+import {WebviewShape} from '../commit_graph/api/webview_shape';
+import {CommitGraphState} from '../commit_graph/api/types';
+
+/**
+ * Implementation of the ExtensionShape that the webview can use to call the
+ * extension.
+ *
+ * TODO: The contents of this file should be replaced by the Google internal code:
+ * devtools/cider/extensions/jj/ui/smart_graph/extension_shape_impl.ts
+ */
+export class ExtensionShapeImpl implements ExtensionShape {
+  constructor(private readonly webviewApi: WebviewShape) {}
+
+  async $webviewReady() {
+    await this.webviewApi.$setStates([createFakeCommitGraphState()]);
+  }
+
+  async $executeCommand() {}
+
+  async $informNewOrder(): Promise<void> {}
+
+  async $informContextMenuWillOpen(): Promise<void> {}
+
+  async $onClick(): Promise<void> {}
+
+  async $clearMultiSelection(): Promise<void> {}
+
+  async $dismissCallout(): Promise<void> {}
+}
+
+// TODO - Replace with a real implementation.
+function createFakeCommitGraphState(): CommitGraphState {
+  return {
+    repoName: 'jj-dojo',
+    callouts: [],
+    commits: [
+      {
+        hash: 'hash',
+        childrenHashes: [],
+        bookmarkChips: [],
+        shortDescription: 'Commit Short Description',
+        fullDescription: 'Commit Full Description',
+        active: true,
+        isEmpty: true,
+        displayId: 'displayId',
+        highlightedDisplayIdLen: 8,
+        updateTime: Date.now(),
+        isMultiSelected: false,
+      },
+    ],
+    topBarButtons: [],
+    options: {
+      showChangeId: true,
+      alwaysShowActions: false,
+      showContextMenuIcon: true,
+    },
+  };
+}

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -16,19 +16,24 @@
 
 import * as vscode from 'vscode';
 import {activateMergeConflict} from './merge_conflict/activate';
+import {CommitGraphViewProvider} from './commit_graph_provider/commit_graph_provider';
+import {dispose} from '../utils/dispose';
 
 /** The main class that contains all jj UI components. */
 export class JjUi implements vscode.Disposable {
   private readonly disposables: vscode.Disposable[] = [];
 
-  constructor() {
+  constructor(context: vscode.ExtensionContext) {
     this.disposables.push(activateMergeConflict());
+    this.disposables.push(
+      vscode.window.registerWebviewViewProvider(
+        CommitGraphViewProvider.viewType,
+        new CommitGraphViewProvider(context.extensionUri),
+      ),
+    );
   }
 
   dispose() {
-    for (const disposable of this.disposables) {
-      disposable.dispose();
-    }
-    this.disposables.length = 0;
+    dispose(this.disposables);
   }
 }


### PR DESCRIPTION
After this PR, jj-dojo is capable of rendering the commit graph using fake data.

* src/ui/commit_graph/webview_module.ts is copied from internal with minimal modifications

<img width="490" height="113" alt="image" src="https://github.com/user-attachments/assets/29727bd1-59c0-4892-aa58-b24590cb7ee1" />
