### PR TITLE
Create BUILD targets for src/ui/commit_graph, third_party/, and other directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 bazel-*
 node_modules/
-out/
 *.log
 package-lock.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,16 +7,13 @@
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionDevelopmentPath=${workspaceFolder}/bazel-bin",
         "--disable-extension",
         "vscode.git",
         "--disable-extension",
         "jj-view.jj-view"
       ],
-      "outFiles": [
-        "${workspaceFolder}/out/**/*.js",
-        "${workspaceFolder}/bazel-bin/out/**/*.js"
-      ],
+      "outFiles": ["${workspaceFolder}/bazel-bin/**/*.js"],
       "preLaunchTask": "Compile extension"
     }
   ]

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -19,7 +19,12 @@ pnpm-lock.yaml
 scripts/**
 spec/**
 src/**
+!src/**/*.js
+!src/**/*.js.map
+!src/**/*.css
 third_party/**
+!third_party/**/*.js
+!third_party/**/*.js.map
 tsconfig.json
 **/*.ts
 **/*__js_binary*/**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,113 +12,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
 load("@aspect_rules_js//js:defs.bzl", "js_library")
-load("@aspect_rules_ts//ts:defs.bzl", "ts_config", "ts_project")
+load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:@vscode/vsce/package_json.bzl", vsce_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
-load("@npm//:jasmine/package_json.bzl", jasmine_bin = "bin")
 
 npm_link_all_packages(name = "node_modules")
 
 ts_config(
     name = "tsconfig",
     src = "tsconfig.json",
+    visibility = ["//visibility:public"],
 )
 
-ts_project(
-    name = "compile",
-    srcs = glob(
-        [
-            "src/**/*.ts",
-            "third_party/**/*.ts",
-        ],
-        exclude = [
-            "src/testing/**",
-            "src/**/*_test.ts",
-            "third_party/**/*_test.ts",
-        ],
-    ),
-    composite = True,
-    out_dir = "out",
-    root_dir = ".",
-    source_map = True,
-    transpiler = "tsc",
-    tsconfig = ":tsconfig",
-    deps = [
-        # TODO: we should declare two bazel targets, one that includes
-        # targets intended to be imported into google, and only depends
-        # on very few dependencies like vscode. The other includes the
-        # rest of the upstream extension, and depends on additional targets
-        # like node. 
-        "//:node_modules/@types/node",
-        "//:node_modules/@types/vscode",
-        "//:node_modules/lit",
-        "//:node_modules/safevalues",
-        "//:node_modules/@vscode-elements/elements",
-    ],
-)
-
-ts_project(
-    name = "compile_test",
-    srcs = glob(
-        [
-            "src/testing/**/*.ts",
-            "src/**/*_test.ts",
-            "third_party/**/*_test.ts",
-        ],
-    ),
-    composite = True,
-    out_dir = "out",
-    root_dir = ".",
-    source_map = True,
-    transpiler = "tsc",
-    tsconfig = ":tsconfig",
-    deps = [
-        "//:node_modules",
-        ":compile",
-    ],
-)
-
-esbuild(
-    name = "webview_bundle",
-    entry_point = "out/src/ui/commit_graph/webview_module.js",
-    output = "out/src/ui/commit_graph/webview_module.bundle.js",
-    format = "esm",
-    target = "es2020",
-    tsconfig = "tsconfig.json",
-    deps = [
-        ":compile",
-        "//:node_modules/lit",
-        "//:node_modules/safevalues",
-        "//:node_modules/@vscode-elements/elements",
-    ],
+js_library(
+    name = "jasmine_config",
+    srcs = ["spec/support/jasmine.json"],
+    visibility = ["//visibility:public"],
 )
 
 js_library(
     name = "extension",
     srcs = [
         "package.json",
-        "src/ui/commit_graph/components/_jj_graph_base_styles.css",
-        ":compile",
-        ":webview_bundle",
-    ],
-)
-
-jasmine_bin.jasmine_test(
-    name = "test",
-    size = "small",
-    args = [
-        "--config=spec/support/jasmine.json",
-    ],
-    chdir = package_name(),
-    data = [
-        "package.json",
-        "tsconfig.json",
-        "spec/support/jasmine.json",
-        "//:node_modules",
-        ":compile",
-        ":compile_test",
+        "//src",
+        "//src/ui/commit_graph:webview_bundle",
+        "//src/ui/commit_graph/components:styles",
     ],
 )
 
@@ -129,6 +48,18 @@ alias(
 
 vsce_bin.vsce(
     name = "vsix",
+    srcs = [
+        ".vscodeignore",
+        "LICENSE",
+        "README.md",
+        "package.json",
+        "//src",
+        "//src/ui/commit_graph:webview_bundle",
+        "//src/ui/commit_graph/components:styles",
+    ],
+    outs = [
+        "jj-dojo.vsix",
+    ],
     args = [
         "package",
         "--allow-missing-repository",
@@ -139,16 +70,4 @@ vsce_bin.vsce(
         "jj-dojo.vsix",
     ],
     chdir = package_name(),
-    outs = [
-        "jj-dojo.vsix",
-    ],
-    srcs = [
-        ".vscodeignore",
-        "LICENSE",
-        "README.md",
-        "package.json",
-        ":compile",
-    ],
 )
-
-

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,6 +21,7 @@ bazel_dep(name = "aspect_rules_js", version = "3.1.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.9")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.26.0")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
+bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,7 +30,7 @@ const allowUnusedVarsWithUnderscorePrefix = {
 };
 
 const globalIgnores = {
-  ignores: ['out/', 'bazel-*'],
+  ignores: ['bazel-*'],
 };
 
 const overrides = [allowUnusedVarsWithUnderscorePrefix];

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "onStartupFinished",
     "workspaceContains:.jj"
   ],
-  "main": "./out/src/extension.js",
+  "main": "./src/extension.js",
   "contributes": {
     "configuration": {},
     "colors": [

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,10 +1,10 @@
 {
-  "spec_dir": "out",
+  "spec_dir": ".",
   "spec_files": [
     "**/*_test.js"
   ],
   "helpers": [
-    "src/testing/install_global_vscode.js"
+    "**/install_global_vscode.js"
   ],
   "requires": []
 }

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "src",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = [
+            "**/*_test.ts",
+        ],
+    ),
+    deps = [
+        # TODO: we should declare two bazel targets, one that includes
+        # targets intended to be imported into google, and only depends
+        # on very few dependencies like vscode. The other includes the
+        # rest of the upstream extension, and depends on additional targets
+        # like node.
+        "//third_party/vscode:rpc_protocol",
+        "//src/ui/commit_graph/api",
+        "//src/utils",
+    ],
+    visibility = ["//:__pkg__"]
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(
+        ["**/*_test.ts"],
+    ),
+    deps = [
+        ":src",
+        "//:node_modules/vscode-uri",
+        "//src/testing",
+    ],
+)

--- a/src/testing/BUILD.bazel
+++ b/src/testing/BUILD.bazel
@@ -1,0 +1,27 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "testing",
+    srcs = glob(["**/*.ts"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//:node_modules/@types/jasmine",
+        "//:node_modules/@types/vscode",
+        "//:node_modules/vscode-uri",
+        "//third_party/vscode:vscode_enums",
+    ],
+)

--- a/src/testing/custom_fakes/fake_window.ts
+++ b/src/testing/custom_fakes/fake_window.ts
@@ -15,6 +15,7 @@
  */
 
 import * as vscode from 'vscode';
+import 'jasmine';
 
 import {FakeLogOutputChannel} from './fake_log_output_channel';
 

--- a/src/testing/install_global_vscode.ts
+++ b/src/testing/install_global_vscode.ts
@@ -16,7 +16,6 @@
 /* eslint-disable  @typescript-eslint/no-explicit-any */
 declare const require: (id: string) => any;
 
-
 // Without this, tests would fail with `Cannot find package 'vscode' ...`
 // because they can't import the vscode module.
 //

--- a/src/ui/commit_graph/BUILD.bazel
+++ b/src/ui/commit_graph/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@aspect_rules_esbuild//esbuild:defs.bzl", "esbuild")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "commit_graph_ts",
+    srcs = glob(["*.ts"]),
+    deps = [
+        "//src/ui/commit_graph/api",
+        "//src/ui/commit_graph/components",
+        "//third_party/vscode:rpc_protocol",
+    ],
+)
+
+js_library(
+    name = "commit_graph_js",
+    srcs = [
+        ":commit_graph_ts",
+    ],
+)
+
+esbuild(
+    name = "webview_bundle",
+    entry_point = "webview_module.js",
+    output = "webview_module.bundle.js",
+    format = "esm",
+    target = "es2020",
+    tsconfig = "//:tsconfig",
+    deps = [
+        ":commit_graph_js",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/ui/commit_graph/algorithms/BUILD.bazel
+++ b/src/ui/commit_graph/algorithms/BUILD.bazel
@@ -1,0 +1,36 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "algorithms",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = ["test_utils.ts"],
+    ),
+    deps = [
+        "//src/ui/commit_graph/api",
+    ],
+    visibility = [
+        "//src/ui/commit_graph:__subpackages__",
+    ],
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(["**/*_test.ts"]) + ["test_utils.ts"],
+    deps = [":algorithms"],
+)

--- a/src/ui/commit_graph/api/BUILD.bazel
+++ b/src/ui/commit_graph/api/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "api",
+    srcs = glob(["**/*.ts"]),
+    visibility = ["//visibility:public"],
+)

--- a/src/ui/commit_graph/components/BUILD.bazel
+++ b/src/ui/commit_graph/components/BUILD.bazel
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@aspect_bazel_lib//lib:copy_to_bin.bzl", "copy_to_bin")
+load("@aspect_rules_js//js:defs.bzl", "js_library")
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+copy_to_bin(
+    name = "styles",
+    srcs = ["_jj_graph_base_styles.css"],
+    visibility = ["//:__pkg__"],
+)
+
+ts_library(
+    name = "components",
+    srcs = glob(
+        ["**/*.ts"],
+    ),
+    deps = [
+        "//:node_modules/@vscode-elements/elements",
+        "//:node_modules/lit",
+        "//:node_modules/safevalues",
+        "//src/ui/commit_graph/algorithms",
+        "//src/ui/commit_graph/api",
+        "//src/ui/commit_graph/utils",
+    ],
+    visibility = ["//src/ui/commit_graph:__pkg__"]
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(["**/*_test.ts"]),
+    deps = [":components"],
+)

--- a/src/ui/commit_graph/utils/BUILD.bazel
+++ b/src/ui/commit_graph/utils/BUILD.bazel
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "utils",
+    srcs = glob(["**/*.ts"]),
+    visibility = [
+        "//src/utils:__subpackages__",
+        "//src/ui/commit_graph:__subpackages__",
+    ],
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(["**/*_test.ts"]),
+    deps = [":utils"],
+)

--- a/src/ui/commit_graph/utils/time_test.ts
+++ b/src/ui/commit_graph/utils/time_test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import 'jasmine';
 import {age} from './time';
 
 describe('time utils', () => {

--- a/src/ui/commit_graph_provider/commit_graph_provider.ts
+++ b/src/ui/commit_graph_provider/commit_graph_provider.ts
@@ -79,8 +79,6 @@ function getHtmlForWebview(
   const scriptUri = webview.asWebviewUri(
     vscode.Uri.joinPath(
       extensionUri,
-      'bazel-bin',
-      'out',
       'src',
       'ui',
       'commit_graph',

--- a/src/utils/BUILD.bazel
+++ b/src/utils/BUILD.bazel
@@ -1,0 +1,32 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "utils",
+    srcs = glob(["*.ts"]),
+    deps = [
+        "//src/ui/commit_graph/utils",
+        "//:node_modules/@types/vscode",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(["**/*_test.ts"]),
+    deps = [":utils"],
+)

--- a/src/utils/hashset_test.ts
+++ b/src/utils/hashset_test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import 'jasmine';
 import {HashMapKey} from './hashmap';
 import {HashSet} from './hashset';
 

--- a/third_party/vscode/BUILD.bazel
+++ b/third_party/vscode/BUILD.bazel
@@ -1,0 +1,38 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/jasmine:defs.bzl", "jasmine_test")
+load("//tools/bazel/typescript:defs.bzl", "ts_library")
+
+ts_library(
+    name = "vscode_enums",
+    srcs = ["vscode_enums.ts"],
+    visibility = [
+        "//src/testing:__pkg__",
+    ],
+)
+
+ts_library(
+    name = "rpc_protocol",
+    srcs = glob(["rpc_protocol/**/*.ts"]),
+    visibility = ["//visibility:public"],
+)
+
+jasmine_test(
+    name = "tests",
+    srcs = glob(["**/*_test.ts"]),
+    deps = [
+        ":rpc_protocol",
+    ],
+)

--- a/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
+++ b/third_party/vscode/rpc_protocol/rpc_protocol_test.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'jasmine';
 import {
   Channel,
   Disposable,

--- a/tools/bazel/jasmine/BUILD.bazel
+++ b/tools/bazel/jasmine/BUILD.bazel
@@ -1,0 +1,14 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tools/bazel/jasmine/defs.bzl
+++ b/tools/bazel/jasmine/defs.bzl
@@ -1,0 +1,64 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common Bazel build macros for Jasmine tests."""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+load("@npm//:jasmine/package_json.bzl", jasmine_bin = "bin")
+
+def jasmine_test(
+        name,
+        srcs,
+        deps = []):
+    """Macro for compiling TypeScript test files and executing Jasmine unit tests.
+
+    Creates a ts_project target to compile test sources with Jasmine types,
+    and a jasmine_bin.jasmine_test target to run the test suite.
+
+    Args:
+        name: Target name.
+        srcs: Test source files list or glob.
+        deps: Dependencies for the test target.
+    """
+    ts_project_name = name + "_ts_project"
+    ts_project(
+        name = ts_project_name,
+        srcs = srcs,
+        composite = True,
+        source_map = True,
+        transpiler = "tsc",
+        tsconfig = "//:tsconfig",
+        deps = deps + [
+            "//:node_modules/@types/jasmine",
+        ],
+    )
+
+    pkg = native.package_name()
+    depth = len(pkg.split("/")) if pkg else 0
+    rel_path = "../" * depth
+
+    jasmine_bin.jasmine_test(
+        name = name,
+        size = "small",
+        args = [
+            "--config=" + rel_path + "spec/support/jasmine.json",
+        ],
+        chdir = pkg,
+        data = [
+            "//:jasmine_config",
+            "//:node_modules",
+            ts_project_name,
+        ],
+    )
+

--- a/tools/bazel/typescript/BUILD.bazel
+++ b/tools/bazel/typescript/BUILD.bazel
@@ -1,0 +1,14 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/tools/bazel/typescript/defs.bzl
+++ b/tools/bazel/typescript/defs.bzl
@@ -1,0 +1,44 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Common Bazel build macros for TypeScript targets."""
+
+load("@aspect_rules_ts//ts:defs.bzl", "ts_project")
+
+def ts_library(
+        name,
+        srcs,
+        **kwargs):
+    """Macro wrapping ts_project for TypeScript libraries, automatically excluding test files.
+
+    Args:
+        name: Target name.
+        srcs: Source files list or glob. Files starting/ending/containing the 'test' keyword
+            are automatically excluded.
+        **kwargs: Additional arguments passed through to ts_project.
+    """
+    srcs = [
+        s
+        for s in srcs
+        if not s.startswith("test_") and not s.endswith("_test.ts") and "_test_" not in s
+    ]
+    ts_project(
+        name = name,
+        srcs = srcs,
+        composite = True,
+        source_map = True,
+        transpiler = "tsc",
+        tsconfig = "//:tsconfig",
+        **kwargs
+    )

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2020",
-    "outDir": "out",
     "lib": ["es2020", "dom"],
-    "rootDirs": [".", "out"],
+    "rootDirs": ["."],
     "sourceMap": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Why do I want to do this:
- I'd like to use BUILD.bazel files to limit what subdirectories can include. For example, I want src/ui/commit_graph to be self-contained and not depend on files outside of that dir. Similarly, I'd like some BUILD targets like //third_party to not include certain node_modules, since those may not be available inside Google.

What changes did I make:
- Before this PR, we dump tsc outputs to an out/ directory. However, the position of the out/ directory depends on where the ts_project rule is defined. This is not a problem when we have a single ts_project rule at the root level. But if we have nested ts_project rules, the output directory looks like this, causing the include in TS files to fail:
  - bazel-bin/third_party/vscode/out/rpc_protocol/rpc_protocol.js
  - bazel-bin/out/src/extension.js
  To fix this, I made tsc dump output in the same directory instead of in out/
- I also defined two BUILD rules in defs.bzl. `ts_library` and `jasmine_test`. They are just convenience methods to avoid typing the same things again and again.
- I also added a lot of BUILD.bazel files in places I found necessary.
