### PR TITLE
Integrate addlicense

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -120,4 +120,26 @@ jobs:
         run: |
           pnpm --dir "$DIR" run lint
 
+  license:
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 10
+    permissions:
+      contents: 'read'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@11d5960a326750d5838078e36cf38b85af677262' # ratchet:actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: 'Setup Bazel'
+        uses: 'bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86' # 0.19.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "${{ github.workflow }}-${{ hashFiles('pnpm-lock.yaml', 'MODULE.bazel', '.bazelrc', 'tsconfig.json') }}"
+          repository-cache: true
+
+      - name: 'Check License Headers'
+        run: bazel run //:addlicense.check
+
+
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,12 @@ load("@aspect_rules_js//js:defs.bzl", "js_library")
 load("@aspect_rules_ts//ts:defs.bzl", "ts_config")
 load("@npm//:@vscode/vsce/package_json.bzl", vsce_bin = "bin")
 load("@npm//:defs.bzl", "npm_link_all_packages")
+load("@npm//:jasmine/package_json.bzl", jasmine_bin = "bin")
+load("//tools/bazel/addlicense:defs.bzl", "addlicense")
+
+addlicense(
+    name = "addlicense",
+)
 
 npm_link_all_packages(name = "node_modules")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,8 +20,13 @@ module(
 bazel_dep(name = "aspect_rules_js", version = "3.1.1")
 bazel_dep(name = "aspect_rules_ts", version = "3.8.9")
 bazel_dep(name = "aspect_rules_esbuild", version = "0.26.0")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "aspect_bazel_lib", version = "2.22.5")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+
+
+
 
 npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
 
@@ -41,3 +46,47 @@ use_repo(pnpm, "pnpm")
 rules_ts_ext = use_extension("@aspect_rules_ts//ts:extensions.bzl", "ext", dev_dependency = True)
 rules_ts_ext.deps()
 use_repo(rules_ts_ext, "npm_typescript")
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "addlicense_linux_amd64",
+    build_file_content = 'exports_files(["addlicense"])',
+    integrity = "sha256-aSQpZ3EjSxumyWnhCbRFnP914Vsllna2Hfh0qSc0skI=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Linux_x86_64.tar.gz"],
+)
+
+http_archive(
+    name = "addlicense_linux_arm64",
+    build_file_content = 'exports_files(["addlicense"])',
+    integrity = "sha256-sU3ehnptvNQf30UJaD4Xf0UAvwE0aT04xWcB4Xnz81M=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Linux_arm64.tar.gz"],
+)
+
+http_archive(
+    name = "addlicense_darwin_amd64",
+    build_file_content = 'exports_files(["addlicense"])',
+    integrity = "sha256-M1tHooqrxuOUlCIv1xwivUDRTW9tCgirnqfG8xVViIM=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_macOS_x86_64.tar.gz"],
+)
+
+http_archive(
+    name = "addlicense_darwin_arm64",
+    build_file_content = 'exports_files(["addlicense"])',
+    integrity = "sha256-BZcwXGGfc0l0joMOODItvn0Tz4bPQVsom8D1zsu0v2M=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_macOS_arm64.tar.gz"],
+)
+
+http_archive(
+    name = "addlicense_windows_amd64",
+    build_file_content = 'exports_files(["addlicense.exe"])',
+    integrity = "sha256-/k9KVOqkp1D/p9Gw2kcdB3rCTwDaTX8fe3lQlp0lS5k=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Windows_x86_64.zip"],
+)
+
+http_archive(
+    name = "addlicense_windows_arm64",
+    build_file_content = 'exports_files(["addlicense.exe"])',
+    integrity = "sha256-MquP906btdVHrLnw7tOW3uHjqG66xqR7t8Ne0mlAsho=",
+    urls = ["https://github.com/google/addlicense/releases/download/v1.2.0/addlicense_v1.2.0_Windows_arm64.zip"],
+)

--- a/tools/bazel/addlicense/BUILD.bazel
+++ b/tools/bazel/addlicense/BUILD.bazel
@@ -1,0 +1,15 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(["defs.bzl"], visibility = ["//visibility:public"])

--- a/tools/bazel/addlicense/defs.bzl
+++ b/tools/bazel/addlicense/defs.bzl
@@ -1,0 +1,17 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//tools/bazel/private/addlicense:addlicense.bzl", _addlicense = "addlicense")
+
+addlicense = _addlicense

--- a/tools/bazel/private/addlicense/BUILD.bazel
+++ b/tools/bazel/private/addlicense/BUILD.bazel
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exports_files(
+    [
+        "addlicense.bzl",
+        "runner.sh",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "linux_x86_64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "linux_arm64",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "macos_x86_64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "macos_arm64",
+    constraint_values = [
+        "@platforms//os:macos",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+config_setting(
+    name = "windows_x86_64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+config_setting(
+    name = "windows_arm64",
+    constraint_values = [
+        "@platforms//os:windows",
+        "@platforms//cpu:aarch64",
+    ],
+)
+
+alias(
+    name = "addlicense",
+    actual = select({
+        ":linux_x86_64": "@addlicense_linux_amd64//:addlicense",
+        ":linux_arm64": "@addlicense_linux_arm64//:addlicense",
+        ":macos_x86_64": "@addlicense_darwin_amd64//:addlicense",
+        ":macos_arm64": "@addlicense_darwin_arm64//:addlicense",
+        ":windows_x86_64": "@addlicense_windows_amd64//:addlicense.exe",
+        ":windows_arm64": "@addlicense_windows_arm64//:addlicense.exe",
+    }),
+    visibility = ["//visibility:public"],
+)
+

--- a/tools/bazel/private/addlicense/addlicense.bzl
+++ b/tools/bazel/private/addlicense/addlicense.bzl
@@ -1,0 +1,69 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Macro generating addlicense .fix and .check targets."""
+
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+
+DEFAULT_IGNORES = [
+    ".git/**",
+    ".jj/**",
+    "node_modules/**",
+    "out/**",
+    "bazel-*/**",
+    "bazel-*",
+    "pnpm-lock.yaml",
+    "MODULE.bazel.lock",
+    "package-lock.json",
+    ".vscode/**",
+    "**/*.json",
+]
+
+def addlicense(name = "addlicense", copyright_holder = "Google LLC", license_type = "apache", extra_ignores = [], **kwargs):
+    ignore_args = []
+    for pattern in DEFAULT_IGNORES + extra_ignores:
+        ignore_args.extend(["-ignore", pattern])
+
+    common_args = ["-l", license_type, "-c", "\"%s\"" % copyright_holder] + ignore_args
+
+    sh_binary(
+        name = name + ".fix",
+        srcs = ["//tools/bazel/private/addlicense:runner.sh"],
+        data = [
+            "//tools/bazel/private/addlicense:addlicense",
+            "@bazel_tools//tools/bash/runfiles",
+        ],
+        args = [
+            "$(rlocationpath //tools/bazel/private/addlicense:addlicense)",
+            "fix",
+        ] + common_args,
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        **kwargs
+    )
+
+    sh_binary(
+        name = name + ".check",
+        srcs = ["//tools/bazel/private/addlicense:runner.sh"],
+        data = [
+            "//tools/bazel/private/addlicense:addlicense",
+            "@bazel_tools//tools/bash/runfiles",
+        ],
+        args = [
+            "$(rlocationpath //tools/bazel/private/addlicense:addlicense)",
+            "check",
+        ] + common_args,
+        deps = ["@bazel_tools//tools/bash/runfiles"],
+        **kwargs
+    )
+

--- a/tools/bazel/private/addlicense/runner.sh
+++ b/tools/bazel/private/addlicense/runner.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# --- begin runfiles.bash initialization v3 ---
+set +e
+f="bazel_tools/tools/bash/runfiles/runfiles.bash"
+# shellcheck disable=SC1090,SC2312
+source "${RUNFILES_DIR:-/dev/null}/${f}" 2>/dev/null || \
+  source "$(grep -sm1 "^${f} " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -f2- -d' ')" 2>/dev/null || \
+  source "${0}.runfiles/${f}" 2>/dev/null || \
+  source "$(grep -sm1 "^${f} " "${0}.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  source "$(grep -sm1 "^${f} " "${0}.exe.runfiles_manifest" | cut -f2- -d' ')" 2>/dev/null || \
+  { echo >&2 "ERROR: cannot find ${f}"; exit 1; }
+set -e
+# --- end runfiles.bash initialization v3 ---
+
+if [[ -z "${BUILD_WORKSPACE_DIRECTORY:-}" ]]; then
+  echo >&2 "ERROR: BUILD_WORKSPACE_DIRECTORY is not set. Execute via 'bazel run'."
+  exit 1
+fi
+
+EXE_RLOCATION="${1}"
+MODE="${2}"
+shift 2
+
+BIN="$(rlocation "${EXE_RLOCATION}")"
+if [[ ! -x "${BIN}" ]]; then
+  echo >&2 "ERROR: addlicense binary not found at ${BIN} (rlocation: ${EXE_RLOCATION})"
+  exit 1
+fi
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+if [[ "${MODE}" == "check" ]]; then
+  exec "${BIN}" -check "$@" .
+else
+  exec "${BIN}" "$@" .
+fi


### PR DESCRIPTION
This adds two new Bazel targets:
- `bazel run //:addlicense.fix` will automatically apply license headers to files in the repo
- `bazel run //:addlicense.check` will fail if any files are missing a license header

The addlicense check is also integrated with CI.