### PR TITLE
Fix unresolved conflict markers in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2410,8 +2410,6 @@ snapshots:
       '@typescript-eslint/types': 8.59.4
       eslint-visitor-keys: 5.0.1
 
-<<<<<<< conflict 1 of 1
-+++++++ svunmpmr fc63cfe0 "Move commit_graph/components to upstream" (rebase destination)
   '@typespec/ts-http-runtime@0.3.8':
     dependencies:
       http-proxy-agent: 7.0.2


### PR DESCRIPTION
Github actions didn't stop this from submitting, probably because our repo didn't have 'Require status checks to pass before merging' checked. I have checked it now.
