### PR TITLE
Support spin modifier in codicons

### DIFF
--- a/src/ui/commit_graph/components/codicon.ts
+++ b/src/ui/commit_graph/components/codicon.ts
@@ -17,6 +17,9 @@
 import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators';
 import {styleMap} from 'lit/directives/style-map';
+import {parseCodicon} from '../utils/codicon';
+
+export {parseCodicon};
 
 @customElement('jj-codicon')
 class JjCodicon extends LitElement {
@@ -44,14 +47,15 @@ class JjCodicon extends LitElement {
     if (this.codicon === 'codicon-checkout') {
       return html`<jj-edit-codicon></jj-edit-codicon>`;
     }
-    let codicon = this.codicon;
-    if (codicon.startsWith('codicon-')) {
-      codicon = codicon.slice('codicon-'.length);
-    }
+    const {name, spin} = parseCodicon(this.codicon);
     const styles = styleMap({
       color: this.color,
     });
-    return html`<vscode-icon name="${codicon}" style=${styles}></vscode-icon>`;
+    return html`<vscode-icon
+      name="${name}"
+      ?spin=${spin}
+      style=${styles}
+    ></vscode-icon>`;
   }
 }
 

--- a/src/ui/commit_graph/components/commit_row_right_side.ts
+++ b/src/ui/commit_graph/components/commit_row_right_side.ts
@@ -21,6 +21,7 @@ import type {ExtensionShape} from '../api/extension_shape';
 import type {CommitGraphState, CommitNode} from '../api/types';
 import {MERGE_TILE_HEIGHT, TILE_HEIGHT} from './constants';
 
+import {parseCodicon} from '../utils/codicon';
 import './commit_row_title';
 import './drag_and_drop_publisher';
 
@@ -84,9 +85,11 @@ class JjCommitRowRightSide extends LitElement {
 
   private renderIconButtons() {
     const buttons = (this.node.iconButtons ?? []).map((button) => {
+      const {name, spin} = parseCodicon(button.icon);
       return html`
         <vscode-icon
-          name=${button.icon}
+          name=${name}
+          ?spin=${spin}
           title=${ifDefined(button.command.tooltip)}
           ?isActivelySelected=${this.node.isMultiSelected}
           action-icon

--- a/src/ui/commit_graph/utils/codicon.ts
+++ b/src/ui/commit_graph/utils/codicon.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Parses a codicon string (e.g. 'codicon-loading~spin', 'loading~spin',
+ * 'codicon-bookmark', 'bookmark') into a base name ('loading' or 'bookmark')
+ * and modifier flags.
+ */
+export function parseCodicon(rawCodicon: string): {
+  name: string;
+  spin: boolean;
+} {
+  let codicon = rawCodicon.trim();
+
+  // Strip codicon- prefix if present.
+  if (codicon.startsWith('codicon-')) {
+    codicon = codicon.slice('codicon-'.length);
+  }
+
+  const spin = codicon.endsWith('~spin');
+  if (spin) {
+    codicon = codicon.slice(0, -5); // since '~spin'.length is 5
+  }
+
+  return {name: codicon, spin};
+}

--- a/src/ui/commit_graph/utils/codicon_test.ts
+++ b/src/ui/commit_graph/utils/codicon_test.ts
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import 'jasmine';
+import {parseCodicon} from './codicon';
+
+describe('parseCodicon', () => {
+  it('sets spin:true for a codicon with ~spin', () => {
+    expect(parseCodicon('loading~spin')).toEqual({name: 'loading', spin: true});
+  });
+
+  it('sets spin:false for a codicon without ~spin', () => {
+    expect(parseCodicon('loading')).toEqual({name: 'loading', spin: false});
+  });
+
+  it('removes the codicon- prefix when provided', () => {
+    expect(parseCodicon('codicon-loading~spin')).toEqual({
+      name: 'loading',
+      spin: true,
+    });
+    expect(parseCodicon('codicon-loading')).toEqual({
+      name: 'loading',
+      spin: false,
+    });
+  });
+
+  it('ignores other suffixes', () => {
+    expect(parseCodicon('loading~foo')).toEqual({
+      name: 'loading~foo',
+      spin: false,
+    });
+  });
+
+  it('ignores other prefixes', () => {
+    expect(parseCodicon('foo-loading')).toEqual({
+      name: 'foo-loading',
+      spin: false,
+    });
+  });
+});


### PR DESCRIPTION
This change introduces a `parseCodicon` utility to parse codicon strings, stripping wrappers/prefixes and extracting modifiers like `~spin`. It updates `jj-codicon` and `commit_row_right_side` to use this utility and conditionally apply the `spin` attribute to `<vscode-icon>`.