### PR TITLE
Remove unused parseCodicon re-export

### DIFF
--- a/src/ui/commit_graph/components/codicon.ts
+++ b/src/ui/commit_graph/components/codicon.ts
@@ -19,8 +19,6 @@ import {customElement, property} from 'lit/decorators';
 import {styleMap} from 'lit/directives/style-map';
 import {parseCodicon} from '../utils/codicon';
 
-export {parseCodicon};
-
 @customElement('jj-codicon')
 class JjCodicon extends LitElement {
   static override styles = [


### PR DESCRIPTION
This was added as part of moving parseCodicon out of components so it could be tested for backwards compatibility, but it is not required so removing it.