### PR TITLE
Make bookmark chip origin customizable

### DIFF
--- a/src/ui/commit_graph/components/commit_row_chip.ts
+++ b/src/ui/commit_graph/components/commit_row_chip.ts
@@ -81,7 +81,6 @@ export class JjCommitRowBookmark extends LitElement {
     openContextMenu({
       dataVscodeContext: JSON.stringify({
         ...this.chip.vscodeContext,
-        origin: 'bookmarkChip',
         preventDefaultContextMenuItems: true,
       }),
       clientX: event.clientX,


### PR DESCRIPTION
This allows the caller to pass in the origin via vscodeContext
