### PR TITLE
Rename BookmarkChip to Chip.

### DIFF
--- a/src/ui/commit_graph/algorithms/preprocess.ts
+++ b/src/ui/commit_graph/algorithms/preprocess.ts
@@ -36,7 +36,7 @@ const ROOT_NODE_BASE: CommitNode = {
   isEmpty: true,
   hasConflict: false,
   hasDiverged: false,
-  bookmarkChips: [],
+  chips: [],
   displayId: 'ROOT_NODE_DISPLAY_ID',
   highlightedDisplayIdLen: 0,
   updateTime: 0,

--- a/src/ui/commit_graph/algorithms/test_utils.ts
+++ b/src/ui/commit_graph/algorithms/test_utils.ts
@@ -30,7 +30,7 @@ export function newCommit(
     childrenHashes: children,
     shortDescription: '',
     fullDescription: '',
-    bookmarkChips: [],
+    chips: [],
     displayId: '',
     highlightedDisplayIdLen: 0,
     updateTime: 0,

--- a/src/ui/commit_graph/api/types.ts
+++ b/src/ui/commit_graph/api/types.ts
@@ -45,7 +45,7 @@ export interface Commit {
 
   readonly hasDiverged?: boolean;
 
-  readonly bookmarkChips: SplitBookmarkChip[];
+  readonly chips: SplitChip[];
 
   // The icon buttons to show when hovered over the commit row.
   readonly iconButtons?: IconButton[];
@@ -91,7 +91,7 @@ export interface IconButton {
 /**
  * The colors of a bookmark chip.
  */
-export interface BookmarkChipColors<T> {
+export interface ChipColors<T> {
   readonly background: T;
   readonly foreground: T;
   readonly border: T;
@@ -279,7 +279,7 @@ export interface CommitGraphState {
 /**
  * A bookmark chip in the commit graph.
  */
-export interface BookmarkChip {
+export interface Chip {
   // The text to display in the chip.
   readonly text?: string;
   // The text to display in the chip when hovered. If undefined, `text` is used.
@@ -290,7 +290,7 @@ export interface BookmarkChip {
   // The command to execute when the chip is clicked.
   // If set, the `link` field will be ignored.
   readonly command?: VSCodeCommand;
-  readonly color: BookmarkChipColors<string>;
+  readonly color: ChipColors<string>;
   // The codicon to display before `text`. e.g. codicon-comment
   readonly codiconBefore?: string;
   // The codicon to display after `text`.
@@ -302,8 +302,8 @@ export interface BookmarkChip {
 /**
  * A split bookmark chip in the commit graph.
  */
-export interface SplitBookmarkChip {
-  readonly left: BookmarkChip;
+export interface SplitChip {
+  readonly left: Chip;
 
   readonly dragAndDropCommands?: {
     // Called when dropped on the garbage section.
@@ -315,7 +315,7 @@ export interface SplitBookmarkChip {
   };
 
   readonly right?: {
-    readonly chip: BookmarkChip;
+    readonly chip: Chip;
     /**
      * In split chips, the left and right border colors are ignored.
      * Instead, the split chip's border color is set to this value.

--- a/src/ui/commit_graph/components/commit_row_chip.ts
+++ b/src/ui/commit_graph/components/commit_row_chip.ts
@@ -18,11 +18,7 @@ import {LitElement, css, html} from 'lit';
 import {customElement, property, state} from 'lit/decorators';
 import {ifDefined} from 'lit/directives/if-defined';
 import type {ExtensionShape} from '../api/extension_shape';
-import type {
-  BookmarkChip,
-  CommitGraphState,
-  SplitBookmarkChip,
-} from '../api/types';
+import type {Chip, CommitGraphState, SplitChip} from '../api/types';
 import {openContextMenu} from '../components/context_menu_provider';
 import {isMac} from './user_agent';
 
@@ -31,11 +27,11 @@ import './codicon';
 /**
  * A component that renders a single bookmark chip.
  */
-@customElement('jj-commit-row-bookmark')
-export class JjCommitRowBookmark extends LitElement {
+@customElement('jj-commit-row-split-chip')
+export class JjCommitRowSplitChip extends LitElement {
   @property({attribute: false}) extensionApi!: ExtensionShape;
   @property({attribute: false}) state!: CommitGraphState;
-  @property({attribute: false}) chip!: SplitBookmarkChip;
+  @property({attribute: false}) chip!: SplitChip;
   @property({attribute: false}) opacity!: string;
 
   static override styles = css`
@@ -47,25 +43,25 @@ export class JjCommitRowBookmark extends LitElement {
   override render() {
     if (this.chip.right) {
       return html`
-        <jj-commit-row-split-chip
+        <jj-commit-row-split-chip-internal
           .state=${this.state}
           .extensionApi=${this.extensionApi}
           .chip=${this.chip}
           style="opacity: ${this.opacity};"
           @contextmenu=${this.openContextMenu}
         >
-        </jj-commit-row-split-chip>
+        </jj-commit-row-split-chip-internal>
       `;
     }
     return html`
-      <jj-commit-row-chip
+      <jj-commit-row-chip-internal
         .state=${this.state}
         .extensionApi=${this.extensionApi}
         .chip=${this.chip.left}
         style="opacity: ${this.opacity};"
         @contextmenu=${this.openContextMenu}
       >
-      </jj-commit-row-chip>
+      </jj-commit-row-chip-internal>
     `;
   }
 
@@ -89,8 +85,8 @@ export class JjCommitRowBookmark extends LitElement {
   };
 }
 
-@customElement('jj-commit-row-split-chip')
-class JjCommitRowSplitChip extends LitElement {
+@customElement('jj-commit-row-split-chip-internal')
+class JjCommitRowSplitChipInternal extends LitElement {
   static override styles = css`
     .wrapper {
       display: flex;
@@ -104,7 +100,7 @@ class JjCommitRowSplitChip extends LitElement {
 
   @property({attribute: false}) extensionApi!: ExtensionShape;
   @property({attribute: false}) state!: CommitGraphState;
-  @property({attribute: false}) chip!: SplitBookmarkChip;
+  @property({attribute: false}) chip!: SplitChip;
 
   override render() {
     return html`
@@ -131,8 +127,8 @@ class JjCommitRowSplitChip extends LitElement {
   }
 }
 
-@customElement('jj-commit-row-chip')
-class JjCommitRowChip extends LitElement {
+@customElement('jj-commit-row-chip-internal')
+class JjCommitRowChipInternal extends LitElement {
   static override styles = css`
     .wrapper {
       border-width: 1px;
@@ -145,7 +141,7 @@ class JjCommitRowChip extends LitElement {
 
   @property({attribute: false}) extensionApi!: ExtensionShape;
   @property({attribute: false}) state!: CommitGraphState;
-  @property({attribute: false}) chip!: BookmarkChip;
+  @property({attribute: false}) chip!: Chip;
 
   override render() {
     return html`<div
@@ -204,7 +200,7 @@ class JjCommitRowChipContent extends LitElement {
 
   @property({attribute: false}) extensionApi!: ExtensionShape;
   @property({attribute: false}) state!: CommitGraphState;
-  @property({attribute: false}) chip!: BookmarkChip;
+  @property({attribute: false}) chip!: Chip;
 
   @state() isHovered = false;
 
@@ -322,9 +318,9 @@ class JjCommitRowChipContent extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'jj-commit-row-chip': JjCommitRowChip;
-    'jj-commit-row-split-chip': JjCommitRowSplitChip;
+    'jj-commit-row-chip-internal': JjCommitRowChipInternal;
+    'jj-commit-row-split-chip-internal': JjCommitRowSplitChipInternal;
     'jj-commit-row-chip-content': JjCommitRowChipContent;
-    'jj-commit-row-bookmark': JjCommitRowBookmark;
+    'jj-commit-row-split-chip': JjCommitRowSplitChip;
   }
 }

--- a/src/ui/commit_graph/components/commit_row_chip_group.ts
+++ b/src/ui/commit_graph/components/commit_row_chip_group.ts
@@ -17,20 +17,15 @@
 import {css, html} from 'lit';
 import {customElement, property} from 'lit/decorators';
 import type {ExtensionShape} from '../api/extension_shape';
-import type {
-  CommitGraphState,
-  CommitNode,
-  SplitBookmarkChip,
-} from '../api/types';
-import {createBookmarkTarget} from './drag_and_drop_state';
+import type {CommitGraphState, CommitNode} from '../api/types';
 import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
 import {COMMIT_ROW_HEIGHT} from './constants';
 
 import './commit_row_chip';
-import './drag_and_drop_publisher';
+import './commit_row_draggable_chip';
 
-@customElement('jj-commit-row-bookmarks')
-class JjCommitRowBookmarks extends JjDragAndDropAllTargetsSubscriber {
+@customElement('jj-commit-row-chip-group')
+class JjCommitRowChipGroup extends JjDragAndDropAllTargetsSubscriber {
   @property({attribute: false}) extensionApi!: ExtensionShape;
   @property({attribute: false}) state!: CommitGraphState;
   @property({attribute: false}) node!: CommitNode;
@@ -46,79 +41,46 @@ class JjCommitRowBookmarks extends JjDragAndDropAllTargetsSubscriber {
 
   override render() {
     return html`${this.renderDraggedBookmark()}
-    ${this.node.bookmarkChips.map(
+    ${this.node.chips.map(
       (chip) =>
-        html`<jj-commit-row-draggable-bookmark
+        html`<jj-commit-row-draggable-split-chip
           .state=${this.state}
           .extensionApi=${this.extensionApi}
           .node=${this.node}
           .chip=${chip}
         >
-        </jj-commit-row-draggable-bookmark>`,
+        </jj-commit-row-draggable-split-chip>`,
     )}`;
   }
 
   private renderDraggedBookmark() {
-    if (
-      this.dragged?.type !== 'bookmark' ||
-      this.dragged.data.node === this.node
-    ) {
+    if (this.dragged?.type !== 'chip' || this.dragged.data.node === this.node) {
       return html``;
     }
     let hoveredNode: CommitNode;
     if (this.hovered?.type === 'commit') {
       hoveredNode = this.hovered.data;
-    } else if (this.hovered?.type === 'bookmark') {
+    } else if (this.hovered?.type === 'chip') {
       hoveredNode = this.hovered.data.node;
     } else {
       return html``;
     }
     if (hoveredNode === this.node) {
       return html`
-        <jj-commit-row-bookmark
+        <jj-commit-row-split-chip
           .state=${this.state}
           .extensionApi=${this.extensionApi}
           .chip=${this.dragged.data.chip}
         >
-        </jj-commit-row-bookmark>
+        </jj-commit-row-split-chip>
       `;
     }
     return html``;
   }
 }
 
-@customElement('jj-commit-row-draggable-bookmark')
-class JjCommitRowDraggableBookmark extends JjDragAndDropAllTargetsSubscriber {
-  @property({attribute: false}) extensionApi!: ExtensionShape;
-  @property({attribute: false}) state!: CommitGraphState;
-  @property({attribute: false}) node!: CommitNode;
-  @property({attribute: false}) chip!: SplitBookmarkChip;
-
-  override render() {
-    const isDragSource =
-      this.dragged?.type === 'bookmark' && this.dragged.data.chip === this.chip;
-    return html`
-      <jj-drag-and-drop-publisher
-        .publishedTarget=${createBookmarkTarget(this.node, this.chip)}
-        .extensionApi=${this.extensionApi}
-        .state=${this.state}
-      >
-        <jj-commit-row-bookmark
-          .state=${this.state}
-          .extensionApi=${this.extensionApi}
-          .chip=${this.chip}
-          .style=${`opacity: ${isDragSource ? 0.3 : 1}`}
-          draggable="true"
-        >
-        </jj-commit-row-bookmark>
-      </jj-drag-and-drop-publisher>
-    `;
-  }
-}
-
 declare global {
   interface HTMLElementTagNameMap {
-    'jj-commit-row-bookmarks': JjCommitRowBookmarks;
-    'jj-commit-row-draggable-bookmark': JjCommitRowDraggableBookmark;
+    'jj-commit-row-chip-group': JjCommitRowChipGroup;
   }
 }

--- a/src/ui/commit_graph/components/commit_row_draggable_chip.ts
+++ b/src/ui/commit_graph/components/commit_row_draggable_chip.ts
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {html} from 'lit';
+import {customElement, property} from 'lit/decorators';
+import type {ExtensionShape} from '../api/extension_shape';
+import type {CommitGraphState, CommitNode, SplitChip} from '../api/types';
+import {createChipTarget} from './drag_and_drop_state';
+import {JjDragAndDropAllTargetsSubscriber} from './drag_and_drop_subscriber';
+
+import './commit_row_chip';
+import './drag_and_drop_publisher';
+
+@customElement('jj-commit-row-draggable-split-chip')
+export class JjCommitRowDraggableSplitChip extends JjDragAndDropAllTargetsSubscriber {
+  @property({attribute: false}) extensionApi!: ExtensionShape;
+  @property({attribute: false}) state!: CommitGraphState;
+  @property({attribute: false}) node!: CommitNode;
+  @property({attribute: false}) chip!: SplitChip;
+
+  override render() {
+    const isDragSource =
+      this.dragged?.type === 'chip' && this.dragged.data.chip === this.chip;
+    return html`
+      <jj-drag-and-drop-publisher
+        .publishedTarget=${createChipTarget(this.node, this.chip)}
+        .extensionApi=${this.extensionApi}
+        .state=${this.state}
+      >
+        <jj-commit-row-split-chip
+          .state=${this.state}
+          .extensionApi=${this.extensionApi}
+          .chip=${this.chip}
+          .style=${`opacity: ${isDragSource ? 0.3 : 1}`}
+          draggable="true"
+        >
+        </jj-commit-row-split-chip>
+      </jj-drag-and-drop-publisher>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'jj-commit-row-draggable-split-chip': JjCommitRowDraggableSplitChip;
+  }
+}

--- a/src/ui/commit_graph/components/commit_row_right_side.ts
+++ b/src/ui/commit_graph/components/commit_row_right_side.ts
@@ -22,7 +22,7 @@ import {RenderMode, type CommitGraphState, type CommitNode} from '../api/types';
 
 import {parseCodicon} from '../utils/codicon';
 import './commit_row_title';
-import './commit_row_bookmarks';
+import './commit_row_chip_group';
 import './drag_and_drop_publisher';
 import './commit_row_display_id';
 
@@ -90,12 +90,12 @@ class JjCommitRowRightSide extends LitElement {
   private renderOneLineMode() {
     return html`
       <div class="commit-row-right-side" draggable="${this.isDraggable}">
-        <jj-commit-row-bookmarks
+        <jj-commit-row-chip-group
           .node=${this.node}
           .extensionApi=${this.extensionApi}
           .state=${this.state}
         >
-        </jj-commit-row-bookmarks>
+        </jj-commit-row-chip-group>
         <jj-commit-row-title
           .extensionApi=${this.extensionApi}
           .state=${this.state}
@@ -119,12 +119,12 @@ class JjCommitRowRightSide extends LitElement {
               .nodes=${this.nodes}
             >
             </jj-commit-row-display-id>
-            <jj-commit-row-bookmarks
+            <jj-commit-row-chip-group
               .node=${this.node}
               .extensionApi=${this.extensionApi}
               .state=${this.state}
             >
-            </jj-commit-row-bookmarks>
+            </jj-commit-row-chip-group>
           </div>
           <jj-commit-row-title
             .extensionApi=${this.extensionApi}

--- a/src/ui/commit_graph/components/drag_and_drop_publisher.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_publisher.ts
@@ -19,12 +19,8 @@ import {LitElement, css, html} from 'lit';
 import {customElement, property} from 'lit/decorators';
 import {classMap} from 'lit/directives/class-map';
 import type {ExtensionShape} from '../api/extension_shape';
-import type {
-  CommitGraphState,
-  CommitNode,
-  SplitBookmarkChip,
-} from '../api/types';
-import {JjCommitRowBookmark} from './commit_row_chip';
+import type {CommitGraphState, CommitNode, SplitChip} from '../api/types';
+import {JjCommitRowSplitChip} from './commit_row_chip';
 import type {Target} from './drag_and_drop_state';
 import {getManager, isNoopInsert} from './drag_and_drop_state';
 
@@ -89,7 +85,7 @@ class JjDragAndDropPublisher extends LitElement {
           }
           let dragImage: HTMLElement | undefined;
           switch (target.type) {
-            case 'bookmark':
+            case 'chip':
               dragImage = this.getBookmarkDragImage(target.data.chip);
               break;
             case 'commit':
@@ -147,13 +143,13 @@ class JjDragAndDropPublisher extends LitElement {
     if (dragged === undefined || hovered === undefined) {
       return;
     }
-    if (dragged.type === 'bookmark') {
+    if (dragged.type === 'chip') {
       const type = hovered.type;
       const {dragAndDropCommands} = dragged.data.chip;
       if (!dragAndDropCommands) {
         return;
       }
-      if (type === 'commit' || type === 'bookmark') {
+      if (type === 'commit' || type === 'chip') {
         let destinationCommit: CommitNode;
         if (hovered.type === 'commit') {
           destinationCommit = hovered.data;
@@ -193,7 +189,7 @@ class JjDragAndDropPublisher extends LitElement {
       const type = hovered.type;
       switch (type) {
         case 'commit':
-        case 'bookmark': {
+        case 'chip': {
           const hoveredCommit =
             hovered.type === 'commit' ? hovered.data : hovered.data.node;
 
@@ -275,8 +271,8 @@ class JjDragAndDropPublisher extends LitElement {
     return blankImage;
   }
 
-  private getBookmarkDragImage(chip: SplitBookmarkChip) {
-    const bookmark = new JjCommitRowBookmark();
+  private getBookmarkDragImage(chip: SplitChip) {
+    const bookmark = new JjCommitRowSplitChip();
     bookmark.state = this.state;
     bookmark.extensionApi = this.extensionApi;
     bookmark.chip = chip;
@@ -303,7 +299,7 @@ export function isDraggable(target: Target, state: CommitGraphState) {
   if (target.type === 'garbageSection' || target.type === 'insert') {
     return false;
   }
-  if (target.type === 'bookmark') {
+  if (target.type === 'chip') {
     return Boolean(target.data.chip.dragAndDropCommands);
   }
 

--- a/src/ui/commit_graph/components/drag_and_drop_state.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_state.ts
@@ -15,7 +15,7 @@
  */
 
 import {checkExhaustive} from '../utils/check';
-import {CommitNode, InsertAction, SplitBookmarkChip} from '../api/types';
+import {CommitNode, InsertAction, SplitChip} from '../api/types';
 import {isMac} from './user_agent';
 
 /** A callback that is called when the drag and drop state changes. */
@@ -37,10 +37,10 @@ export type Target =
       data: InsertAction;
     }
   | {
-      type: 'bookmark';
+      type: 'chip';
       data: {
         node: CommitNode;
-        chip: SplitBookmarkChip;
+        chip: SplitChip;
       };
     };
 
@@ -65,16 +65,16 @@ export function createInsertTarget(
   };
 }
 
-/** Creates a target that represents a bookmark. */
-export function createBookmarkTarget(
-  node: CommitNode,
-  chip: SplitBookmarkChip,
-): Target {
+/** Creates a target that represents a chip. */
+export function createChipTarget(node: CommitNode, chip: SplitChip): Target {
   return {
-    type: 'bookmark',
+    type: 'chip',
     data: {node, chip},
   };
 }
+
+/** @deprecated Use createChipTarget instead. */
+export const createBookmarkTarget = createChipTarget;
 
 /** A target that represents the garbage section. */
 export const GARBAGE_SECTION_TARGET: Target = {
@@ -99,9 +99,9 @@ export function isEqual(a: Target | undefined, b: Target | undefined) {
         a.data.from === b.data.from &&
         a.data.to === b.data.to
       );
-    case 'bookmark':
+    case 'chip':
       return (
-        b.type === 'bookmark' &&
+        b.type === 'chip' &&
         a.data.node === b.data.node &&
         a.data.chip === b.data.chip
       );
@@ -118,7 +118,7 @@ export function isNoopInsert(
   draggedTarget: Target | undefined,
   hoveredTarget: Target | undefined,
 ): boolean {
-  if (draggedTarget?.type === 'bookmark') {
+  if (draggedTarget?.type === 'chip') {
     return (
       hoveredTarget?.type !== 'commit' ||
       draggedTarget.data.node === hoveredTarget.data

--- a/src/ui/commit_graph/components/drag_and_drop_state_test.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_state_test.ts
@@ -30,7 +30,7 @@ function newCommitNode(node: Partial<CommitNode>): CommitNode {
     shortDescription: '',
     fullDescription: '',
     isEmpty: false,
-    bookmarkChips: [],
+    chips: [],
     displayId: '',
     highlightedDisplayIdLen: 0,
     updateTime: 0,

--- a/src/ui/commit_graph/components/drag_and_drop_subscriber.ts
+++ b/src/ui/commit_graph/components/drag_and_drop_subscriber.ts
@@ -57,11 +57,11 @@ export class JjDragAndDropSubscriber extends LitElement {
     const dragged = getManager().getDragged();
     let hovered = getManager().getHovered();
 
-    // When dragging a commit or a bookmark onto a bookmark, we still want to show it's
+    // When dragging a commit or a chip onto a chip, we still want to show it's
     // the commit that is being hovered over.
     if (
-      (dragged?.type === 'commit' || dragged?.type === 'bookmark') &&
-      hovered?.type === 'bookmark'
+      (dragged?.type === 'commit' || dragged?.type === 'chip') &&
+      hovered?.type === 'chip'
     ) {
       hovered = {
         type: 'commit',

--- a/src/ui/commit_graph/components/glyph_tile.ts
+++ b/src/ui/commit_graph/components/glyph_tile.ts
@@ -153,8 +153,7 @@ class JjGlyphTile extends JjDragAndDropAllTargetsSubscriber {
       this.dragged?.type === 'commit' &&
       this.dragged.data !== this.node &&
       ((this.hovered?.type === 'commit' && this.hovered.data === this.node) ||
-        (this.hovered?.type === 'bookmark' &&
-          this.hovered.data.node === this.node))
+        (this.hovered?.type === 'chip' && this.hovered.data.node === this.node))
     );
   }
 

--- a/src/ui/commit_graph_provider/extension_shape_impl.ts
+++ b/src/ui/commit_graph_provider/extension_shape_impl.ts
@@ -54,7 +54,7 @@ function createFakeCommitGraphState(): CommitGraphState {
       {
         hash: 'hash',
         childrenHashes: [],
-        bookmarkChips: [],
+        chips: [],
         shortDescription: 'Commit Short Description',
         fullDescription: 'Commit Full Description',
         active: true,


### PR DESCRIPTION
We've started using chips in various ways, including for bookmarks, for workspaces, for CLs, etc. So the bookmark chip name should be updated.
