### PR TITLE
Retain commit graph webview context even when not visible

### DIFF
--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -40,6 +40,11 @@ export class JjUi extends JjUiBase {
       vscode.window.registerWebviewViewProvider(
         CommitGraphViewProvider.viewType,
         new CommitGraphViewProvider(context.extensionUri),
+        {
+          webviewOptions: {
+            retainContextWhenHidden: true,
+          },
+        },
       ),
     );
   }


### PR DESCRIPTION
We don't want to recycle the commit graph whenever the user hides the view.
